### PR TITLE
Fix feature bugs and unify UI/UX across all pages

### DIFF
--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+/**
+ * Card
+ *
+ * Shared card surface used across the app. Variants:
+ *   - default  → solid surface, subtle border
+ *   - elevated → solid surface, soft drop-shadow on hover
+ *   - glass    → translucent surface with backdrop blur
+ *   - gradient → faint primary→secondary tint
+ *
+ * Use this everywhere instead of writing `bg-surface border border-border
+ * rounded-lg p-…` ad-hoc. Padding is configurable via the `padding` prop.
+ */
+const paddingMap = {
+    none: '',
+    xs: 'p-2',
+    sm: 'p-3',
+    md: 'p-4',
+    lg: 'p-6',
+    xl: 'p-8',
+};
+
+const variantMap = {
+    default: 'bg-surface border border-border',
+    elevated: 'bg-surface border border-border shadow-sm hover:shadow-md transition-shadow',
+    glass: 'bg-surface/70 backdrop-blur-xl border border-border/40',
+    gradient: 'bg-gradient-to-br from-primary/5 via-secondary/5 to-accent/5 border border-border/40',
+    outline: 'border border-border bg-transparent',
+};
+
+const Card = React.forwardRef(({
+    children,
+    variant = 'default',
+    padding = 'md',
+    interactive = false,
+    className = '',
+    as: Component = 'div',
+    ...rest
+}, ref) => {
+    const variantCls = variantMap[variant] || variantMap.default;
+    const paddingCls = paddingMap[padding] ?? paddingMap.md;
+    const interactiveCls = interactive
+        ? 'cursor-pointer hover:border-primary/40 hover:shadow-md transition-all'
+        : '';
+
+    return (
+        <Component
+            ref={ref}
+            className={`rounded-xl ${variantCls} ${paddingCls} ${interactiveCls} ${className}`.trim()}
+            {...rest}
+        >
+            {children}
+        </Component>
+    );
+});
+
+Card.displayName = 'Card';
+
+export default Card;

--- a/src/components/ui/EmptyState.jsx
+++ b/src/components/ui/EmptyState.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import Icon from '../AppIcon';
+
+/**
+ * EmptyState
+ *
+ * Used wherever a list / dashboard / tab has no content yet.
+ * Replaces the various inline "no data" blocks scattered across pages.
+ *
+ *   <EmptyState
+ *     icon="Trophy"
+ *     title="No achievements yet"
+ *     description="Keep working on your goals to unlock achievements!"
+ *     action={<Button>Create one</Button>}
+ *   />
+ */
+const EmptyState = ({
+    icon = 'Inbox',
+    title,
+    description,
+    action,
+    secondaryAction,
+    className = '',
+    size = 'md', // 'sm' | 'md' | 'lg'
+}) => {
+    const sizeCls = {
+        sm: { wrap: 'py-6', icon: 'w-12 h-12', iconInner: 'w-6 h-6', title: 'text-base', desc: 'text-xs' },
+        md: { wrap: 'py-10', icon: 'w-16 h-16', iconInner: 'w-8 h-8', title: 'text-lg', desc: 'text-sm' },
+        lg: { wrap: 'py-16', icon: 'w-20 h-20', iconInner: 'w-10 h-10', title: 'text-xl', desc: 'text-base' },
+    }[size] || {};
+
+    return (
+        <div className={`flex flex-col items-center justify-center text-center ${sizeCls.wrap} ${className}`}>
+            <div className={`${sizeCls.icon} rounded-2xl bg-gradient-to-br from-primary/10 via-secondary/10 to-accent/10 border border-border/40 flex items-center justify-center mb-4`}>
+                <Icon name={icon} className={`${sizeCls.iconInner} text-primary`} />
+            </div>
+            {title && (
+                <h3 className={`${sizeCls.title} font-heading-semibold text-text-primary mb-1`}>
+                    {title}
+                </h3>
+            )}
+            {description && (
+                <p className={`${sizeCls.desc} text-text-secondary max-w-md mb-4`}>
+                    {description}
+                </p>
+            )}
+            {(action || secondaryAction) && (
+                <div className="flex flex-wrap items-center justify-center gap-2 mt-2">
+                    {action}
+                    {secondaryAction}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default EmptyState;

--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -56,7 +56,7 @@ const Header = () => {
   const handleLogout = async () => {
     try {
       await logout();
-      navigate('/auth/login');
+      navigate('/login');
     } catch (error) {
       console.error('Logout failed:', error);
     }

--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -1,0 +1,128 @@
+import React, { useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import Icon from '../AppIcon';
+
+/**
+ * Modal
+ *
+ * Unified modal shell. Replaces the many ad-hoc
+ *   `<div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">`
+ * blocks that vary slightly across the app.
+ *
+ *   <Modal isOpen={open} onClose={…} title="Add Event" icon="Calendar">
+ *     {body}
+ *   </Modal>
+ */
+const sizeMap = {
+    sm: 'max-w-sm',
+    md: 'max-w-md',
+    lg: 'max-w-lg',
+    xl: 'max-w-xl',
+    '2xl': 'max-w-2xl',
+    '3xl': 'max-w-3xl',
+    '4xl': 'max-w-4xl',
+};
+
+const Modal = ({
+    isOpen,
+    onClose,
+    title,
+    icon,
+    description,
+    children,
+    footer,
+    size = 'md',
+    closeOnBackdrop = true,
+    showClose = true,
+    className = '',
+    bodyClassName = '',
+}) => {
+    // Close on Escape
+    useEffect(() => {
+        if (!isOpen) return;
+        const onKey = (e) => {
+            if (e.key === 'Escape' && onClose) onClose();
+        };
+        document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+    }, [isOpen, onClose]);
+
+    // Lock background scroll while open
+    useEffect(() => {
+        if (!isOpen) return;
+        const original = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        return () => { document.body.style.overflow = original; };
+    }, [isOpen]);
+
+    const widthCls = sizeMap[size] || sizeMap.md;
+
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <motion.div
+                    key="modal-backdrop"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.18 }}
+                    className="fixed inset-0 z-[1000] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+                    onClick={() => closeOnBackdrop && onClose && onClose()}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label={typeof title === 'string' ? title : undefined}
+                >
+                    <motion.div
+                        key="modal-panel"
+                        initial={{ opacity: 0, scale: 0.96, y: 10 }}
+                        animate={{ opacity: 1, scale: 1, y: 0 }}
+                        exit={{ opacity: 0, scale: 0.96, y: 10 }}
+                        transition={{ duration: 0.18, ease: 'easeOut' }}
+                        onClick={(e) => e.stopPropagation()}
+                        className={`relative w-full ${widthCls} bg-surface border border-border rounded-2xl shadow-2xl overflow-hidden ${className}`}
+                    >
+                        {(title || icon || showClose) && (
+                            <div className="flex items-start gap-3 px-5 sm:px-6 py-4 border-b border-border/60">
+                                {icon && (
+                                    <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-gradient-to-br from-primary to-secondary flex items-center justify-center">
+                                        <Icon name={icon} className="w-5 h-5 text-white" />
+                                    </div>
+                                )}
+                                <div className="flex-1 min-w-0">
+                                    {title && (
+                                        <h2 className="text-lg font-heading-semibold text-text-primary truncate">
+                                            {title}
+                                        </h2>
+                                    )}
+                                    {description && (
+                                        <p className="text-sm text-text-secondary mt-0.5">{description}</p>
+                                    )}
+                                </div>
+                                {showClose && (
+                                    <button
+                                        type="button"
+                                        onClick={onClose}
+                                        className="flex-shrink-0 -mr-1 p-1.5 text-text-secondary hover:text-text-primary hover:bg-surface-700/40 rounded-lg transition-colors"
+                                        aria-label="Close"
+                                    >
+                                        <Icon name="X" className="w-5 h-5" />
+                                    </button>
+                                )}
+                            </div>
+                        )}
+                        <div className={`px-5 sm:px-6 py-5 max-h-[70vh] overflow-y-auto ${bodyClassName}`}>
+                            {children}
+                        </div>
+                        {footer && (
+                            <div className="px-5 sm:px-6 py-3 border-t border-border/60 bg-surface-700/20 flex flex-wrap items-center justify-end gap-2">
+                                {footer}
+                            </div>
+                        )}
+                    </motion.div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+};
+
+export default Modal;

--- a/src/components/ui/Page.jsx
+++ b/src/components/ui/Page.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+/**
+ * Page
+ *
+ * Canonical wrapper used by every top-level page in the app. Provides:
+ *   - the standard `min-h-screen bg-background` chrome
+ *   - a centered max-width container with consistent horizontal padding
+ *   - vertical padding that matches across pages so the gap below the
+ *     fixed Header is identical everywhere
+ *   - a soft entrance animation for visual continuity between routes
+ *
+ * Pages should NOT add their own `pt-20` / `max-w-*` / `bg-background` —
+ * use this wrapper so layouts stay aligned.
+ */
+const widthMap = {
+    sm: 'max-w-3xl',
+    md: 'max-w-5xl',
+    lg: 'max-w-6xl',
+    xl: 'max-w-7xl',
+    full: 'max-w-none',
+};
+
+const Page = ({
+    children,
+    width = 'xl',
+    className = '',
+    contentClassName = '',
+    animate = true,
+    background = 'default', // 'default' | 'gradient' | 'none'
+}) => {
+    const widthCls = widthMap[width] || widthMap.xl;
+
+    const backgroundCls =
+        background === 'gradient'
+            ? 'min-h-screen bg-gradient-to-br from-background via-background to-surface/40'
+            : background === 'none'
+                ? 'min-h-screen'
+                : 'min-h-screen bg-background';
+
+    const Inner = animate ? motion.div : 'div';
+    const motionProps = animate
+        ? { initial: { opacity: 0, y: 8 }, animate: { opacity: 1, y: 0 }, transition: { duration: 0.25, ease: 'easeOut' } }
+        : {};
+
+    return (
+        <div className={`${backgroundCls} ${className}`}>
+            <Inner
+                {...motionProps}
+                className={`${widthCls} mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 ${contentClassName}`}
+            >
+                {children}
+            </Inner>
+        </div>
+    );
+};
+
+export default Page;

--- a/src/components/ui/PageHeader.jsx
+++ b/src/components/ui/PageHeader.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import Icon from '../AppIcon';
+
+/**
+ * PageHeader
+ *
+ * Canonical page header used at the top of every main page.
+ *
+ *   <PageHeader
+ *      icon="UtensilsCrossed"
+ *      title="Meals"
+ *      subtitle="Plan and track your macro-optimized meals"
+ *      actions={<Button>...</Button>}
+ *   />
+ *
+ * Renders a gradient icon tile, a heading, an optional subtitle, and a
+ * right-aligned slot for action buttons. Keeps spacing consistent across
+ * dashboards (Goals, Habits, Meals, Journal, Progress, Analytics, etc.).
+ */
+const PageHeader = ({
+    icon,
+    iconElement,
+    title,
+    subtitle,
+    actions,
+    badge,
+    className = '',
+    align = 'between',
+}) => {
+    const layoutCls =
+        align === 'center'
+            ? 'flex flex-col items-center text-center gap-4'
+            : 'flex flex-col md:flex-row md:items-center md:justify-between gap-4';
+
+    return (
+        <header className={`mb-6 sm:mb-8 ${className}`}>
+            <div className={layoutCls}>
+                <div className="flex items-center gap-3 sm:gap-4 min-w-0">
+                    {(icon || iconElement) && (
+                        <div className="flex-shrink-0 w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-gradient-to-br from-primary via-secondary to-accent flex items-center justify-center shadow-lg shadow-primary/20">
+                            {iconElement || (
+                                <Icon name={icon} className="w-6 h-6 text-white" />
+                            )}
+                        </div>
+                    )}
+
+                    <div className="min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <h1 className="text-2xl sm:text-3xl font-heading-bold text-text-primary tracking-tight truncate">
+                                {title}
+                            </h1>
+                            {badge && (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-primary/10 text-primary border border-primary/20">
+                                    {badge}
+                                </span>
+                            )}
+                        </div>
+                        {subtitle && (
+                            <p className="text-sm sm:text-base text-text-secondary mt-1">
+                                {subtitle}
+                            </p>
+                        )}
+                    </div>
+                </div>
+
+                {actions && (
+                    <div className="flex flex-wrap items-center gap-2 sm:gap-3 md:flex-shrink-0">
+                        {actions}
+                    </div>
+                )}
+            </div>
+        </header>
+    );
+};
+
+export default PageHeader;

--- a/src/components/ui/StatCard.jsx
+++ b/src/components/ui/StatCard.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import Icon from '../AppIcon';
+import Card from './Card';
+
+/**
+ * StatCard
+ *
+ * Small metric card used on dashboards (Goals, Meals, Journal, Progress,
+ * Analytics, Achievements). Replaces the various ad-hoc
+ * `bg-surface border border-border rounded-lg p-4` snippets so every
+ * dashboard's "Total / Completed / Streak / …" row matches.
+ */
+const toneMap = {
+    default: 'text-text-primary',
+    primary: 'text-primary',
+    secondary: 'text-secondary',
+    accent: 'text-accent',
+    success: 'text-success',
+    warning: 'text-warning',
+    error: 'text-error',
+    info: 'text-blue-500',
+};
+
+const iconBgMap = {
+    default: 'bg-surface-700/40 text-text-secondary',
+    primary: 'bg-primary/10 text-primary',
+    secondary: 'bg-secondary/10 text-secondary',
+    accent: 'bg-accent/10 text-accent',
+    success: 'bg-success/10 text-success',
+    warning: 'bg-warning/10 text-warning',
+    error: 'bg-error/10 text-error',
+    info: 'bg-blue-500/10 text-blue-500',
+};
+
+const StatCard = ({
+    icon,
+    label,
+    value,
+    sublabel,
+    tone = 'default',
+    trend,
+    className = '',
+}) => {
+    const valueCls = toneMap[tone] || toneMap.default;
+    const iconCls = iconBgMap[tone] || iconBgMap.default;
+
+    return (
+        <Card padding="md" className={`flex items-start gap-3 ${className}`}>
+            {icon && (
+                <div className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${iconCls}`}>
+                    <Icon name={icon} className="w-5 h-5" />
+                </div>
+            )}
+            <div className="flex-1 min-w-0">
+                <div className="text-xs sm:text-sm text-text-secondary truncate">{label}</div>
+                <div className={`text-2xl font-heading-bold mt-0.5 ${valueCls}`}>
+                    {value}
+                </div>
+                {(sublabel || trend) && (
+                    <div className="flex items-center gap-2 mt-0.5">
+                        {sublabel && (
+                            <span className="text-xs text-text-muted">{sublabel}</span>
+                        )}
+                        {trend && (
+                            <span
+                                className={`text-xs font-medium flex items-center gap-0.5 ${
+                                    trend.direction === 'up'
+                                        ? 'text-success'
+                                        : trend.direction === 'down'
+                                            ? 'text-error'
+                                            : 'text-text-muted'
+                                }`}
+                            >
+                                <Icon
+                                    name={
+                                        trend.direction === 'up'
+                                            ? 'TrendingUp'
+                                            : trend.direction === 'down'
+                                                ? 'TrendingDown'
+                                                : 'Minus'
+                                    }
+                                    className="w-3 h-3"
+                                />
+                                {trend.value}
+                            </span>
+                        )}
+                    </div>
+                )}
+            </div>
+        </Card>
+    );
+};
+
+export default StatCard;

--- a/src/components/ui/TabBar.jsx
+++ b/src/components/ui/TabBar.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import Icon from '../AppIcon';
+
+/**
+ * TabBar
+ *
+ * Unified tab switcher used by Meals, Settings, Analytics, Achievements,
+ * Progress, etc. Active tab uses the standard primary→secondary gradient.
+ *
+ *   <TabBar
+ *     tabs={[{ id: 'plan', label: 'Weekly Plan', icon: 'Calendar' }, …]}
+ *     activeTab={activeTab}
+ *     onChange={setActiveTab}
+ *   />
+ */
+const TabBar = ({
+    tabs,
+    activeTab,
+    onChange,
+    variant = 'pill', // 'pill' | 'underline' | 'segmented'
+    size = 'md',
+    fullWidth = false,
+    className = '',
+}) => {
+    if (!Array.isArray(tabs) || tabs.length === 0) return null;
+
+    const sizeCls =
+        size === 'sm' ? 'text-xs px-3 py-1.5' : size === 'lg' ? 'text-base px-5 py-3' : 'text-sm px-4 py-2';
+
+    if (variant === 'underline') {
+        return (
+            <div className={`border-b border-border flex gap-1 overflow-x-auto ${className}`} role="tablist">
+                {tabs.map((tab) => {
+                    const isActive = activeTab === tab.id;
+                    return (
+                        <button
+                            key={tab.id}
+                            type="button"
+                            role="tab"
+                            aria-selected={isActive}
+                            onClick={() => onChange(tab.id)}
+                            className={`relative ${sizeCls} font-medium whitespace-nowrap flex items-center gap-2 transition-colors ${
+                                isActive
+                                    ? 'text-primary'
+                                    : 'text-text-secondary hover:text-text-primary'
+                            }`}
+                        >
+                            {tab.icon && <Icon name={tab.icon} className="w-4 h-4" />}
+                            <span>{tab.label}</span>
+                            {tab.count != null && (
+                                <span className="ml-1 text-[10px] px-1.5 py-0.5 rounded-full bg-surface-700/60 text-text-muted">
+                                    {tab.count}
+                                </span>
+                            )}
+                            {isActive && (
+                                <motion.span
+                                    layoutId="tabbar-underline"
+                                    className="absolute left-0 right-0 -bottom-px h-0.5 bg-gradient-to-r from-primary to-secondary"
+                                />
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
+        );
+    }
+
+    // 'pill' (default) and 'segmented' share the rounded-pill container
+    const containerCls =
+        variant === 'segmented'
+            ? 'inline-flex bg-surface-700/40 border border-border/40 rounded-lg p-1'
+            : 'inline-flex bg-surface-700/30 border border-border/30 rounded-xl p-1';
+
+    return (
+        <div className={`${fullWidth ? 'flex' : 'inline-flex'} ${className}`} role="tablist">
+            <div className={`${containerCls} ${fullWidth ? 'flex-1 flex' : ''} gap-1 overflow-x-auto`}>
+                {tabs.map((tab) => {
+                    const isActive = activeTab === tab.id;
+                    return (
+                        <button
+                            key={tab.id}
+                            type="button"
+                            role="tab"
+                            aria-selected={isActive}
+                            onClick={() => onChange(tab.id)}
+                            className={`relative ${sizeCls} font-medium whitespace-nowrap flex items-center gap-2 rounded-lg transition-colors ${
+                                fullWidth ? 'flex-1 justify-center' : ''
+                            } ${
+                                isActive
+                                    ? 'text-white'
+                                    : 'text-text-secondary hover:text-text-primary'
+                            }`}
+                        >
+                            {isActive && (
+                                <motion.span
+                                    layoutId="tabbar-pill-active"
+                                    className="absolute inset-0 rounded-lg bg-gradient-to-r from-primary to-secondary shadow-md shadow-primary/20"
+                                    transition={{ type: 'spring', bounce: 0.2, duration: 0.4 }}
+                                />
+                            )}
+                            <span className="relative z-10 flex items-center gap-2">
+                                {tab.icon && <Icon name={tab.icon} className="w-4 h-4" />}
+                                <span>{tab.label}</span>
+                                {tab.count != null && (
+                                    <span
+                                        className={`ml-1 text-[10px] px-1.5 py-0.5 rounded-full ${
+                                            isActive
+                                                ? 'bg-white/20 text-white'
+                                                : 'bg-surface-700/60 text-text-muted'
+                                        }`}
+                                    >
+                                        {tab.count}
+                                    </span>
+                                )}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+export default TabBar;

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -19,8 +19,8 @@ const NotFound = () => {
           </div>
         </div>
 
-        <h2 className="text-2xl font-medium text-onBackground mb-2">Page Not Found</h2>
-        <p className="text-onBackground/70 mb-8">
+        <h2 className="text-2xl font-medium text-text-primary mb-2">Page Not Found</h2>
+        <p className="text-text-secondary mb-8">
           The page you're looking for doesn't exist. Let's get you back!
         </p>
 

--- a/src/pages/achievements/index.jsx
+++ b/src/pages/achievements/index.jsx
@@ -4,18 +4,24 @@ import { useAchievements } from '../../context/AchievementContext';
 import Button from '../../components/ui/Button';
 import Icon from '../../components/AppIcon';
 import AchievementBadge from '../../components/ui/AchievementBadge';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import StatCard from '../../components/ui/StatCard';
+import TabBar from '../../components/ui/TabBar';
+import EmptyState from '../../components/ui/EmptyState';
+import Card from '../../components/ui/Card';
 
 const AchievementsPage = () => {
   const { user, isAuthenticated } = useAuth();
-  const { 
-    achievements, 
-    userPoints, 
-    getAchievementsByState, 
+  const {
+    achievements,
+    userPoints,
+    getAchievementsByState,
     getProgressSummary,
     getAchievementsByCategory,
-    showAllAchievementsModal 
+    showAllAchievementsModal
   } = useAchievements();
-  
+
   const [activeTab, setActiveTab] = useState('all');
   const [activeCategory, setActiveCategory] = useState('all');
   const [isLoading, setIsLoading] = useState(true);
@@ -28,40 +34,36 @@ const AchievementsPage = () => {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-      </div>
+      <Page>
+        <div className="flex items-center justify-center py-20">
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary"></div>
+        </div>
+      </Page>
     );
   }
 
   if (!isAuthenticated) {
     return (
-      <div className="min-h-screen bg-background">
-        <main className="pt-20 pb-24 md:pb-8">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="text-center">
-              <h1 className="text-2xl font-heading-bold text-text-primary mb-4">
-                Achievements
-              </h1>
-              <p className="text-text-secondary">
-                Please log in to view your achievements.
-              </p>
-            </div>
-          </div>
-        </main>
-      </div>
+      <Page>
+        <PageHeader icon="Trophy" title="Achievements" />
+        <EmptyState
+          icon="Lock"
+          title="Sign in to view your achievements"
+          description="Track your progress and unlock rewards as you reach milestones."
+          size="lg"
+        />
+      </Page>
     );
   }
 
   const achievementsByState = getAchievementsByState();
   const progressSummary = getProgressSummary();
-  const achievementsByCategory = getAchievementsByCategory();
 
   const tabs = [
     { id: 'all', label: 'All', icon: 'Trophy', count: progressSummary.total },
     { id: 'completed', label: 'Completed', icon: 'CheckCircle', count: progressSummary.completed },
     { id: 'inProgress', label: 'In Progress', icon: 'Clock', count: progressSummary.inProgress },
-    { id: 'notStarted', label: 'Not Started', icon: 'Lock', count: progressSummary.notStarted }
+    { id: 'notStarted', label: 'Not Started', icon: 'Lock', count: progressSummary.notStarted },
   ];
 
   const categories = [
@@ -70,13 +72,12 @@ const AchievementsPage = () => {
     { id: 'focus', label: 'Focus', icon: 'Timer' },
     { id: 'streaks', label: 'Streaks', icon: 'Flame' },
     { id: 'milestones', label: 'Milestones', icon: 'CheckSquare' },
-    { id: 'special', label: 'Special', icon: 'Star' }
+    { id: 'special', label: 'Special', icon: 'Star' },
   ];
 
   const getAchievementsToShow = () => {
     let filteredAchievements = [];
-    
-    // Filter by state
+
     switch (activeTab) {
       case 'completed':
         filteredAchievements = achievementsByState.completed;
@@ -91,15 +92,12 @@ const AchievementsPage = () => {
         filteredAchievements = [
           ...achievementsByState.completed,
           ...achievementsByState.inProgress,
-          ...achievementsByState.notStarted
+          ...achievementsByState.notStarted,
         ];
     }
 
-    // Filter by category
     if (activeCategory !== 'all') {
-      filteredAchievements = filteredAchievements.filter(achievement => 
-        achievement.category === activeCategory
-      );
+      filteredAchievements = filteredAchievements.filter(a => a.category === activeCategory);
     }
 
     return filteredAchievements;
@@ -136,185 +134,135 @@ const AchievementsPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      <main className="pt-20 pb-24 md:pb-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Header */}
-          <div className="mb-8">
-            <div className="flex items-center justify-between mb-4">
-              <h1 className="text-3xl font-heading-bold text-text-primary">Achievements</h1>
-              <div className="flex items-center space-x-2 px-3 py-2 bg-surface-700 rounded-lg">
-                <Icon name="Trophy" size={16} className="text-primary" />
-                <span className="text-sm font-body-medium text-text-primary">{userPoints} Points</span>
-              </div>
-            </div>
-            
-            {/* Progress Summary */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-              <div className="bg-surface rounded-lg p-4 border border-border">
-                <div className="text-center">
-                  <p className="text-2xl font-heading-bold text-primary">{progressSummary.total}</p>
-                  <p className="text-sm text-text-secondary">Total</p>
-                </div>
-              </div>
-              <div className="bg-surface rounded-lg p-4 border border-border">
-                <div className="text-center">
-                  <p className="text-2xl font-heading-bold text-success">{progressSummary.completed}</p>
-                  <p className="text-sm text-text-secondary">Completed</p>
-                </div>
-              </div>
-              <div className="bg-surface rounded-lg p-4 border border-border">
-                <div className="text-center">
-                  <p className="text-2xl font-heading-bold text-warning">{progressSummary.inProgress}</p>
-                  <p className="text-sm text-text-secondary">In Progress</p>
-                </div>
-              </div>
-              <div className="bg-surface rounded-lg p-4 border border-border">
-                <div className="text-center">
-                  <p className="text-2xl font-heading-bold text-text-muted">{progressSummary.completionRate}%</p>
-                  <p className="text-sm text-text-secondary">Completion</p>
-                </div>
-              </div>
-            </div>
-
-            {/* Tabs */}
-            <div className="flex flex-wrap gap-2 mb-6">
-              {tabs.map((tab) => (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`
-                    flex items-center space-x-2 px-4 py-2 rounded-lg text-sm font-body-medium transition-colors
-                    ${activeTab === tab.id
-                      ? 'bg-primary text-primary-foreground'
-                      : 'text-text-secondary hover:text-text-primary hover:bg-surface-700'
-                    }
-                  `}
-                >
-                  <Icon name={tab.icon} size={16} />
-                  <span>{tab.label}</span>
-                  <span className="bg-white/20 px-2 py-1 rounded text-xs">{tab.count}</span>
-                </button>
-              ))}
-            </div>
-
-            {/* Category Filters */}
-            <div className="flex flex-wrap gap-2 mb-6">
-              {categories.map((category) => (
-                <button
-                  key={category.id}
-                  onClick={() => setActiveCategory(category.id)}
-                  className={`
-                    flex items-center space-x-2 px-3 py-2 rounded-lg text-sm font-body-medium transition-colors
-                    ${activeCategory === category.id
-                      ? 'bg-accent text-accent-foreground'
-                      : 'text-text-secondary hover:text-text-primary hover:bg-surface-700'
-                    }
-                  `}
-                >
-                  <Icon name={category.icon} size={14} />
-                  <span>{category.label}</span>
-                </button>
-              ))}
-            </div>
+    <Page>
+      <PageHeader
+        icon="Trophy"
+        title="Achievements"
+        subtitle="Track milestones, build streaks, and earn rewards"
+        actions={(
+          <div className="flex items-center gap-2 px-3 py-2 bg-gradient-to-r from-primary/10 to-secondary/10 border border-primary/20 rounded-xl">
+            <Icon name="Trophy" size={16} className="text-primary" />
+            <span className="text-sm font-medium text-text-primary">{userPoints} Points</span>
           </div>
+        )}
+      />
 
-          {/* Achievements Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {getAchievementsToShow().length === 0 ? (
-              <div className="col-span-full text-center py-12">
-                <Icon name="Trophy" size={64} className="text-text-muted mx-auto mb-4" />
-                <h3 className="text-xl font-heading-medium text-text-primary mb-2">
-                  {activeTab === 'completed' ? 'No completed achievements yet' :
-                   activeTab === 'inProgress' ? 'No achievements in progress' :
-                   activeTab === 'notStarted' ? 'All achievements started!' :
-                   'No achievements found'}
-                </h3>
-                <p className="text-text-secondary mb-4">
-                  {activeTab === 'completed' ? 'Keep working on your goals to unlock achievements!' :
-                   activeTab === 'inProgress' ? 'Start working on your goals to see progress here' :
-                   activeTab === 'notStarted' ? 'Great job! You\'ve started working on all available achievements' :
-                   'Start using the app to unlock achievements'}
-                </p>
-                <Button variant="outline" onClick={() => window.history.back()}>
-                  Go Back
-                </Button>
+      {/* Progress Summary */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 mb-6">
+        <StatCard icon="Trophy" label="Total" value={progressSummary.total} tone="primary" />
+        <StatCard icon="CheckCircle" label="Completed" value={progressSummary.completed} tone="success" />
+        <StatCard icon="Clock" label="In Progress" value={progressSummary.inProgress} tone="warning" />
+        <StatCard icon="Percent" label="Completion" value={`${progressSummary.completionRate}%`} tone="accent" />
+      </div>
+
+      {/* Tabs */}
+      <div className="mb-4">
+        <TabBar tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
+      </div>
+
+      {/* Category Filters */}
+      <div className="flex flex-wrap gap-2 mb-6">
+        {categories.map((category) => (
+          <button
+            key={category.id}
+            onClick={() => setActiveCategory(category.id)}
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border ${
+              activeCategory === category.id
+                ? 'bg-accent/10 text-accent border-accent/30'
+                : 'bg-surface text-text-secondary border-border hover:text-text-primary hover:border-border-strong'
+            }`}
+          >
+            <Icon name={category.icon} size={14} />
+            <span>{category.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Achievements Grid */}
+      {getAchievementsToShow().length === 0 ? (
+        <EmptyState
+          icon="Trophy"
+          title={
+            activeTab === 'completed' ? 'No completed achievements yet' :
+              activeTab === 'inProgress' ? 'No achievements in progress' :
+                activeTab === 'notStarted' ? 'All achievements started!' :
+                  'No achievements found'
+          }
+          description={
+            activeTab === 'completed' ? 'Keep working on your goals to unlock achievements.' :
+              activeTab === 'inProgress' ? 'Start working on your goals to see progress here.' :
+                activeTab === 'notStarted' ? "Great job! You've started working on all available achievements." :
+                  'Start using the app to unlock achievements.'
+          }
+          size="lg"
+        />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+          {getAchievementsToShow().map((achievement) => (
+            <Card
+              key={achievement.id}
+              variant="elevated"
+              padding="lg"
+              className={`${achievement.earned ? 'border-success/30' : ''}`}
+            >
+              <div className="flex items-start justify-between mb-4">
+                <AchievementBadge
+                  achievement={achievement}
+                  size="large"
+                  showProgress
+                />
+                <div className={`px-2 py-1 rounded-md text-xs font-medium border ${getStateColor(achievement.state)}`}>
+                  {achievement.state === 'completed' ? 'Completed' :
+                    achievement.state === 'in-progress' ? 'In Progress' : 'Not Started'}
+                </div>
               </div>
-            ) : (
-              getAchievementsToShow().map((achievement) => (
-                <div
-                  key={achievement.id}
-                  className={`
-                    bg-surface rounded-lg p-6 border transition-all duration-200 hover:shadow-lg
-                    ${achievement.earned ? 'border-success/20' : 'border-border'}
-                  `}
-                >
-                  <div className="flex items-start justify-between mb-4">
-                    <AchievementBadge
-                      achievement={achievement}
-                      size="large"
-                      showProgress
-                    />
-                    <div className={`
-                      px-2 py-1 rounded text-xs font-body-medium
-                      ${getStateColor(achievement.state)}
-                    `}>
-                      {achievement.state === 'completed' ? 'Completed' :
-                       achievement.state === 'in-progress' ? 'In Progress' : 'Not Started'}
-                    </div>
+
+              <div className="space-y-3">
+                <div>
+                  <h3 className="text-lg font-heading-semibold text-text-primary mb-1">
+                    {achievement.title}
+                  </h3>
+                  <p className="text-sm text-text-secondary">
+                    {achievement.description}
+                  </p>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className={`px-2 py-1 rounded-md text-xs font-medium border ${getCategoryColor(achievement.category)}`}>
+                    {achievement.category}
                   </div>
-
-                  <div className="space-y-3">
-                    <div>
-                      <h3 className="text-lg font-heading-semibold text-text-primary mb-1">
-                        {achievement.title}
-                      </h3>
-                      <p className="text-sm text-text-secondary">
-                        {achievement.description}
-                      </p>
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <div className={`
-                        px-2 py-1 rounded text-xs font-body-medium
-                        ${getCategoryColor(achievement.category)}
-                      `}>
-                        {achievement.category}
-                      </div>
-                      <div className="text-sm font-body-medium text-primary">
-                        +{achievement.points} points
-                      </div>
-                    </div>
-
-                    {achievement.earned && achievement.earnedAt && (
-                      <div className="text-xs text-success">
-                        Earned {new Date(achievement.earnedAt).toLocaleDateString()}
-                      </div>
-                    )}
-
-                    {!achievement.earned && achievement.progress > 0 && (
-                      <div className="space-y-2">
-                        <div className="flex justify-between text-xs text-text-secondary">
-                          <span>Progress</span>
-                          <span>{achievement.progress}/{achievement.total}</span>
-                        </div>
-                        <div className="w-full bg-surface-700 rounded-full h-2">
-                          <div
-                            className="bg-primary h-2 rounded-full transition-all duration-300"
-                            style={{ width: `${achievement.percentage}%` }}
-                          />
-                        </div>
-                      </div>
-                    )}
+                  <div className="text-sm font-medium text-primary">
+                    +{achievement.points} points
                   </div>
                 </div>
-              ))
-            )}
-          </div>
+
+                {achievement.earned && achievement.earnedAt && (
+                  <div className="text-xs text-success">
+                    Earned {new Date(achievement.earnedAt).toLocaleDateString()}
+                  </div>
+                )}
+
+                {!achievement.earned && achievement.progress > 0 && (
+                  <div className="space-y-2">
+                    <div className="flex justify-between text-xs text-text-secondary">
+                      <span>Progress</span>
+                      <span>{achievement.progress}/{achievement.total}</span>
+                    </div>
+                    <div className="w-full bg-surface-700/60 rounded-full h-2 overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-gradient-to-r from-primary to-secondary transition-all duration-300"
+                        style={{ width: `${achievement.percentage}%` }}
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            </Card>
+          ))}
         </div>
-      </main>
-    </div>
+      )}
+    </Page>
   );
 };
 
-export default AchievementsPage; 
+export default AchievementsPage;

--- a/src/pages/ai-assistant-chat-drift/index.jsx
+++ b/src/pages/ai-assistant-chat-drift/index.jsx
@@ -9,6 +9,9 @@ import { geminiService } from '../../services/geminiService';
 import contextAggregationService from '../../services/contextAggregationService';
 import firestoreService from '../../services/firestoreService';
 import Icon from '../../components/ui/Icon';
+import Button from '../../components/ui/Button';
+import Page from '../../components/ui/Page';
+import EmptyState from '../../components/ui/EmptyState';
 import MessageBubble from './components/MessageBubble';
 import MessageInput from './components/MessageInput';
 import WelcomeScreen from './components/WelcomeScreen';
@@ -282,60 +285,57 @@ const DriftChat = () => {
   // Loading/Error States
   if (!user?.id) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
-        <div className="glass-card p-8 text-center max-w-md">
-          <div className="w-16 h-16 bg-error/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <Icon name="AlertCircle" className="w-8 h-8 text-error" />
-          </div>
-          <h3 className="text-xl font-bold text-text-primary mb-2">Sign In Required</h3>
-          <p className="text-text-secondary mb-4">Please sign in to chat with Drift.</p>
-          <button onClick={() => navigate('/login')} className="btn-primary">
-            Sign In
-          </button>
-        </div>
-      </div>
+      <Page width="sm">
+        <EmptyState
+          icon="AlertCircle"
+          title="Sign In Required"
+          description="Please sign in to chat with Drift."
+          action={(
+            <Button variant="primary" onClick={() => navigate('/login')}>Sign In</Button>
+          )}
+          size="lg"
+        />
+      </Page>
     );
   }
 
   if (!settings?.geminiApiKey) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
-        <div className="glass-card p-8 text-center max-w-md">
-          <div className="w-16 h-16 bg-warning/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <Icon name="Key" className="w-8 h-8 text-warning" />
-          </div>
-          <h3 className="text-xl font-bold text-text-primary mb-2">API Key Required</h3>
-          <p className="text-text-secondary mb-4">Configure your Gemini API key in Settings to use Drift.</p>
-          <button onClick={() => navigate('/settings-configuration')} className="btn-primary">
-            Go to Settings
-          </button>
-        </div>
-      </div>
+      <Page width="sm">
+        <EmptyState
+          icon="Key"
+          title="API Key Required"
+          description="Configure your Gemini API key in Settings to use Drift."
+          action={(
+            <Button variant="primary" onClick={() => navigate('/settings-configuration')}>Go to Settings</Button>
+          )}
+          size="lg"
+        />
+      </Page>
     );
   }
 
   if (apiKeyStatus === 'invalid') {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
-        <div className="glass-card p-8 text-center max-w-md">
-          <div className="w-16 h-16 bg-error/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <Icon name="AlertCircle" className="w-8 h-8 text-error" />
-          </div>
-          <h3 className="text-xl font-bold text-text-primary mb-2">Invalid API Key</h3>
-          <p className="text-text-secondary mb-4">Your Gemini API key appears to be invalid.</p>
-          <button onClick={() => navigate('/settings-configuration')} className="btn-primary">
-            Update Settings
-          </button>
-        </div>
-      </div>
+      <Page width="sm">
+        <EmptyState
+          icon="AlertCircle"
+          title="Invalid API Key"
+          description="Your Gemini API key appears to be invalid."
+          action={(
+            <Button variant="primary" onClick={() => navigate('/settings-configuration')}>Update Settings</Button>
+          )}
+          size="lg"
+        />
+      </Page>
     );
   }
 
   if (apiKeyStatus === 'checking') {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="text-center">
-          <div className="relative w-16 h-16 mx-auto mb-4">
+      <Page width="sm">
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <div className="relative w-16 h-16 mb-4">
             <div className="absolute inset-0 bg-gradient-to-r from-primary via-secondary to-accent rounded-2xl blur-lg opacity-50 animate-pulse" />
             <div className="relative w-16 h-16 bg-gradient-to-br from-primary via-secondary to-accent rounded-2xl flex items-center justify-center">
               <Icon name="Sparkles" className="w-8 h-8 text-white animate-pulse" />
@@ -344,7 +344,7 @@ const DriftChat = () => {
           <h3 className="text-lg font-bold text-text-primary mb-2">Initializing Drift</h3>
           <p className="text-text-secondary">Connecting to AI services...</p>
         </div>
-      </div>
+      </Page>
     );
   }
 

--- a/src/pages/analytics-dashboard/index.jsx
+++ b/src/pages/analytics-dashboard/index.jsx
@@ -5,6 +5,9 @@ import analyticsService from '../../services/analyticsService';
 import Button from '../../components/ui/Button';
 import Icon from '../../components/AppIcon';
 import AchievementBadge from '../../components/ui/AchievementBadge';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import TabBar from '../../components/ui/TabBar';
 import { getUserId, getFocusSessionStats, getUserStreakData } from '../../utils/userUtils';
 
 // Analytics Components
@@ -410,89 +413,54 @@ const AnalyticsDashboard = () => {
   );
 
   return (
-    <div className="min-h-screen bg-background">
-      <main className="pt-20 pb-24 md:pb-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Demo Banner for unauthenticated users */}
-          {!isAuthenticated && (
-            <div className="bg-gradient-to-r from-primary/20 to-accent/20 border border-primary/30 rounded-lg p-4 mb-6">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-3">
-                  <Icon name="Eye" size={20} className="text-primary" />
-                  <div>
-                    <h3 className="text-sm font-heading-semibold text-primary">Demo Mode</h3>
-                    <p className="text-xs text-text-secondary">You're viewing demo analytics data. Sign in to see your real data.</p>
-                  </div>
-                </div>
-                <Button size="sm" onClick={() => window.location.href = '/login'}>
-                  Sign In
-                </Button>
+    <Page>
+      {/* Demo Banner for unauthenticated users */}
+      {!isAuthenticated && (
+        <div className="bg-gradient-to-r from-primary/15 to-accent/15 border border-primary/30 rounded-xl p-4 mb-6">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Icon name="Eye" size={20} className="text-primary" />
+              <div>
+                <h3 className="text-sm font-heading-semibold text-primary">Demo Mode</h3>
+                <p className="text-xs text-text-secondary">You're viewing demo analytics data. Sign in to see your real data.</p>
               </div>
             </div>
-          )}
-
-          {/* Header */}
-          <div className="mb-8">
-            <div className="flex items-center justify-between mb-4">
-              <h1 className="text-3xl font-heading-bold text-text-primary">Analytics Dashboard</h1>
-              <div className="flex items-center space-x-4">
-                <select
-                  value={timeRange}
-                  onChange={(e) => setTimeRange(e.target.value)}
-                  className="px-3 py-2 bg-surface border border-border rounded-lg text-sm"
-                >
-                  <option value="week">Last Week</option>
-                  <option value="month">Last Month</option>
-                  <option value="quarter">Last Quarter</option>
-                  <option value="year">Last Year</option>
-                </select>
-              </div>
-            </div>
+            <Button size="sm" onClick={() => window.location.href = '/login'}>
+              Sign In
+            </Button>
           </div>
+        </div>
+      )}
 
-          {/* Tab Navigation */}
-          <div
-            className="flex flex-wrap gap-2 mb-6"
-            role="tablist"
-            aria-label="Analytics Dashboard Tabs"
-            onKeyDown={e => {
-              if (['ArrowLeft', 'ArrowRight'].includes(e.key)) {
-                e.preventDefault();
-                const idx = tabs.findIndex(tab => tab.id === activeTab);
-                let nextIdx = e.key === 'ArrowLeft' ? idx - 1 : idx + 1;
-                if (nextIdx < 0) nextIdx = tabs.length - 1;
-                if (nextIdx >= tabs.length) nextIdx = 0;
-                setActiveTab(tabs[nextIdx].id);
-                // Move focus to the new tab
-                document.getElementById(`dashboard-tab-${tabs[nextIdx].id}`)?.focus();
-              }
-            }}
+      <PageHeader
+        icon="BarChart3"
+        title="Analytics Dashboard"
+        subtitle="Trends, predictions, and patterns across your goals and habits"
+        actions={(
+          <select
+            value={timeRange}
+            onChange={(e) => setTimeRange(e.target.value)}
+            className="px-3 py-2 bg-surface border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50"
           >
-            {tabs.map((tab) => (
-              <button
-                key={tab.id}
-                id={`dashboard-tab-${tab.id}`}
-                onClick={() => setActiveTab(tab.id)}
-                className={
-                  `flex items-center space-x-2 px-4 py-2 rounded-lg text-sm font-body-medium transition-colors
-                  ${activeTab === tab.id
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-text-secondary hover:text-text-primary hover:bg-surface-700'
-                  }`
-                }
-                role="tab"
-                aria-selected={activeTab === tab.id}
-                aria-controls={`dashboard-tabpanel-${tab.id}`}
-                tabIndex={activeTab === tab.id ? 0 : -1}
-              >
-                <Icon name={tab.icon} size={16} />
-                <span>{tab.label}</span>
-              </button>
-            ))}
-          </div>
+            <option value="week">Last Week</option>
+            <option value="month">Last Month</option>
+            <option value="quarter">Last Quarter</option>
+            <option value="year">Last Year</option>
+          </select>
+        )}
+      />
 
-          {/* Tab Content */}
-          <div className="space-y-6">
+      {/* Tab Navigation */}
+      <TabBar
+        tabs={tabs}
+        activeTab={activeTab}
+        onChange={setActiveTab}
+        variant="pill"
+        className="mb-6"
+      />
+
+      {/* Tab Content */}
+      <div className="space-y-6">
             {isLoading ? (
               <div className="flex items-center justify-center py-12">
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
@@ -565,10 +533,8 @@ const AnalyticsDashboard = () => {
                 </div>
               </>
             )}
-          </div>
-        </div>
-      </main>
-    </div>
+      </div>
+    </Page>
   );
 };
 

--- a/src/pages/day/index.jsx
+++ b/src/pages/day/index.jsx
@@ -3,6 +3,10 @@ import { motion, AnimatePresence } from 'framer-motion';
 import FloatingActionButton from '../../components/ui/FloatingActionButton';
 import Icon from '../../components/AppIcon';
 import Button from '../../components/ui/Button';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import EmptyState from '../../components/ui/EmptyState';
+import Modal from '../../components/ui/Modal';
 import { useAuth } from '../../context/AuthContext';
 import { getGoals } from '../../utils/goalUtils';
 import { geminiService } from '../../services/geminiService';
@@ -35,35 +39,37 @@ const AddEventModal = ({ isOpen, onClose, onAdd }) => {
     onClose();
   };
 
-  if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-      <div className="bg-surface rounded-xl shadow-lg p-6 w-full max-w-md relative">
-        <button className="absolute top-3 right-3 text-xl" onClick={onClose}>&times;</button>
-        <h2 className="text-xl font-heading-bold mb-4">Add Event</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1">Title</label>
-            <input name="title" value={form.title} onChange={handleChange} className="w-full px-3 py-2 rounded border border-border bg-surface-700 text-text-primary" required />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Time</label>
-            <input name="time" value={form.time} onChange={handleChange} type="time" className="w-full px-3 py-2 rounded border border-border bg-surface-700 text-text-primary" required />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Category</label>
-            <input name="category" value={form.category} onChange={handleChange} className="w-full px-3 py-2 rounded border border-border bg-surface-700 text-text-primary" placeholder="(Optional)" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Description</label>
-            <textarea name="description" value={form.description} onChange={handleChange} className="w-full px-3 py-2 rounded border border-border bg-surface-700 text-text-primary" rows={2} placeholder="(Optional)" />
-          </div>
-          <div className="flex justify-end">
-            <Button type="submit" variant="primary">Add Event</Button>
-          </div>
-        </form>
-      </div>
-    </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      icon="Calendar"
+      title="Add Event"
+      size="md"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-text-primary mb-1">Title</label>
+          <input name="title" value={form.title} onChange={handleChange} className="w-full px-3 py-2 rounded-lg border border-border bg-surface-700/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-text-primary mb-1">Time</label>
+          <input name="time" value={form.time} onChange={handleChange} type="time" className="w-full px-3 py-2 rounded-lg border border-border bg-surface-700/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-text-primary mb-1">Category</label>
+          <input name="category" value={form.category} onChange={handleChange} className="w-full px-3 py-2 rounded-lg border border-border bg-surface-700/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50" placeholder="(Optional)" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-text-primary mb-1">Description</label>
+          <textarea name="description" value={form.description} onChange={handleChange} className="w-full px-3 py-2 rounded-lg border border-border bg-surface-700/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50" rows={2} placeholder="(Optional)" />
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button type="submit" variant="primary">Add Event</Button>
+        </div>
+      </form>
+    </Modal>
   );
 };
 
@@ -79,58 +85,59 @@ const PreferencesModal = ({ isOpen, onClose, eventCount, setEventCount, novelty,
     onClose();
   };
 
-  if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-      <div className="bg-surface rounded-xl shadow-lg p-6 w-full max-w-md relative">
-        <button className="absolute top-3 right-3 text-xl" onClick={onClose}>&times;</button>
-        <h2 className="text-xl font-heading-bold mb-4">Preferences</h2>
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1">Number of Events</label>
-            <select
-              value={eventCount}
-              onChange={e => setEventCount(Number(e.target.value))}
-              className="w-full px-3 py-2 rounded border border-border bg-surface-700 text-text-primary"
-            >
-              {[5, 8, 11, 14, 18, 23].map(val => (
-                <option key={val} value={val}>{val} events</option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Novelty Level</label>
-            <select
-              value={novelty}
-              onChange={e => setNovelty(e.target.value)}
-              className="w-full px-3 py-2 rounded border border-border bg-surface-700 text-text-primary"
-            >
-              <option value="low">Low Novelty</option>
-              <option value="balanced">Balanced</option>
-              <option value="high">High Novelty</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Ask Drift for Help</label>
-            <textarea
-              value={driftPrompt}
-              onChange={e => setDriftPrompt(e.target.value)}
-              className="w-full px-3 py-2 rounded border border-border bg-surface-700 text-text-primary"
-              rows={2}
-              placeholder="Ask Drift to help plan your day..."
-            />
-            <Button
-              onClick={handleDriftPlan}
-              loading={isDriftLoading}
-              iconName="Bot"
-              className="mt-2"
-            >
-              Ask Drift
-            </Button>
-          </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      icon="Settings"
+      title="Preferences"
+      size="md"
+    >
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-text-primary mb-1">Number of Events</label>
+          <select
+            value={eventCount}
+            onChange={e => setEventCount(Number(e.target.value))}
+            className="w-full px-3 py-2 rounded-lg border border-border bg-surface-700/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50"
+          >
+            {[5, 8, 11, 14, 18, 23].map(val => (
+              <option key={val} value={val}>{val} events</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-text-primary mb-1">Novelty Level</label>
+          <select
+            value={novelty}
+            onChange={e => setNovelty(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-border bg-surface-700/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50"
+          >
+            <option value="low">Low Novelty</option>
+            <option value="balanced">Balanced</option>
+            <option value="high">High Novelty</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-text-primary mb-1">Ask Drift for Help</label>
+          <textarea
+            value={driftPrompt}
+            onChange={e => setDriftPrompt(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-border bg-surface-700/50 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50"
+            rows={2}
+            placeholder="Ask Drift to help plan your day..."
+          />
+          <Button
+            onClick={handleDriftPlan}
+            loading={isDriftLoading}
+            iconName="Bot"
+            className="mt-2"
+          >
+            Ask Drift
+          </Button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 
@@ -443,7 +450,7 @@ const DayPlanner = () => {
       return;
     }
 
-    setIsDriftLoading(true);
+    setIsGenerating(true);
     try {
       // Create a more specific prompt for day planning
       const enhancedPrompt = `Create a daily schedule for: "${prompt}"
@@ -490,7 +497,6 @@ Focus on realistic timing and achievable goals. Return ONLY the JSON array.`;
             
             setDayPlan(processedPlan);
             savePlan(processedPlan);
-            setDriftPrompt(''); // Clear the input
             return;
           }
         } catch (parseError) {
@@ -505,7 +511,7 @@ Focus on realistic timing and achievable goals. Return ONLY the JSON array.`;
       console.error('Drift planning error:', error);
       alert('Failed to get a plan from Drift. Please check your API key and try again.');
     } finally {
-      setIsDriftLoading(false);
+      setIsGenerating(false);
     }
   };
 
@@ -525,43 +531,53 @@ Focus on realistic timing and achievable goals. Return ONLY the JSON array.`;
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-background">
-        <div className="container mx-auto px-4 py-8 max-w-4xl">
-          <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
-            <p className="text-text-secondary">Loading Day Planner...</p>
-          </div>
+      <Page width="lg">
+        <div className="flex flex-col items-center justify-center py-20">
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary mb-4"></div>
+          <p className="text-text-secondary">Loading Day Planner...</p>
         </div>
-      </div>
+      </Page>
     );
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto px-2 pt-24 max-w-4xl">
-        {/* Google Calendar Sync Button */}
-        <div className="flex justify-end mb-2">
-          <div className="flex items-center space-x-2">
+    <Page width="lg">
+      <PageHeader
+        icon="Calendar"
+        title="Day"
+        subtitle="Plan your day with AI-powered scheduling"
+        actions={(
+          <>
             <Button
               variant="outline"
               iconName="Calendar"
               onClick={handleGoogleLink}
+              size="sm"
             >
-              Link Google Calendar
+              Link Calendar
             </Button>
             <Button
-              variant="ghost"
-              iconName="X"
-              onClick={handleSkipGoogleCalendar}
-              className="text-text-secondary hover:text-text-primary"
+              variant="outline"
+              iconName="Settings"
+              onClick={() => setShowPreferences(true)}
+              size="sm"
             >
-              Skip
+              Preferences
             </Button>
-          </div>
-        </div>
-        {syncStatus && (
-          <div className="text-center text-sm text-accent mb-2">{syncStatus}</div>
+            <Button
+              variant="primary"
+              iconName="Plus"
+              onClick={() => setShowAddModal(true)}
+              size="sm"
+            >
+              Add Event
+            </Button>
+          </>
         )}
+      />
+      {syncStatus && (
+        <div className="text-center text-sm text-accent mb-4">{syncStatus}</div>
+      )}
         {/* Dopamine Confetti Celebration */}
         <AnimatePresence>
           {showConfetti && (
@@ -605,73 +621,47 @@ Focus on realistic timing and achievable goals. Return ONLY the JSON array.`;
             </motion.div>
           )}
         </AnimatePresence>
-        <div className="flex flex-col items-center text-center mb-6">
-          <h1 className="text-3xl sm:text-4xl font-extrabold text-primary drop-shadow mb-2">Day</h1>
-          <p className="text-lg text-text-secondary font-medium mb-2">Plan your day with AI-powered scheduling</p>
-        </div>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-3">
-          <div></div>
-          <div className="flex items-center space-x-2">
-            <input
-              type="date"
-              value={selectedDate}
-              onChange={(e) => setSelectedDate(e.target.value)}
-              className="px-3 py-2 bg-surface border border-border rounded-lg text-text-primary"
-            />
-            <Button
-              variant="outline"
-              iconName="Settings"
-              onClick={() => setShowPreferences(true)}
-              className="ml-1"
-            >
-              Preferences
-            </Button>
-            {isConnected ? (
-              <Button
-                onClick={generateDailyPlan}
-                loading={isGenerating}
-                iconName="Calendar"
-                iconPosition="left"
-              >
-                Generate Plan
-              </Button>
-            ) : (
-              <div className="text-error text-sm">API key required</div>
-            )}
-            <Button
-              variant="outline"
-              iconName="Plus"
-              onClick={() => setShowAddModal(true)}
-              className="ml-1"
-            >
-              Add Event
-            </Button>
-          </div>
-        </div>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-6">
+        <input
+          type="date"
+          value={selectedDate}
+          onChange={(e) => setSelectedDate(e.target.value)}
+          className="px-3 py-2 bg-surface border border-border rounded-lg text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50"
+        />
+        {isConnected ? (
+          <Button
+            onClick={generateDailyPlan}
+            loading={isGenerating}
+            iconName="Sparkles"
+            iconPosition="left"
+          >
+            Generate Plan
+          </Button>
+        ) : (
+          <div className="text-error text-sm">API key required</div>
+        )}
+      </div>
 
-        {!settings.geminiApiKey ? (
-          <div className="text-center py-12">
-            <Icon name="Calendar" className="w-16 h-16 mx-auto text-text-muted mb-4" />
-            <h3 className="text-xl font-semibold text-text-primary mb-2">API Key Required</h3>
-            <p className="text-text-secondary">
-              Please configure your Gemini API key in Settings to generate daily plans.
-            </p>
-          </div>
-        ) : !isConnected ? (
-          <div className="text-center py-12">
-            <Icon name="AlertCircle" className="w-16 h-16 mx-auto text-error mb-4" />
-            <h3 className="text-xl font-semibold text-text-primary mb-2">Connection Failed</h3>
-            <p className="text-text-secondary">
-              Unable to connect to Gemini API. Please check your API key in Settings.
-            </p>
-          </div>
-        ) : dayPlan.length === 0 ? (
-          <div className="text-center py-12">
-            <Icon name="Calendar" className="w-16 h-16 mx-auto text-text-muted mb-4" />
-            <h3 className="text-xl font-semibold text-text-primary mb-2">No Plan Generated</h3>
-            <p className="text-text-secondary mb-6">
-              Generate an AI-powered daily plan based on your goals and preferences.
-            </p>
+      {!settings.geminiApiKey ? (
+        <EmptyState
+          icon="Key"
+          title="API Key Required"
+          description="Please configure your Gemini API key in Settings to generate daily plans."
+          size="lg"
+        />
+      ) : !isConnected ? (
+        <EmptyState
+          icon="AlertCircle"
+          title="Connection Failed"
+          description="Unable to connect to Gemini API. Please check your API key in Settings."
+          size="lg"
+        />
+      ) : dayPlan.length === 0 ? (
+        <EmptyState
+          icon="Calendar"
+          title="No Plan Generated"
+          description="Generate an AI-powered daily plan based on your goals and preferences."
+          action={(
             <Button
               onClick={generateDailyPlan}
               loading={isGenerating}
@@ -680,8 +670,10 @@ Focus on realistic timing and achievable goals. Return ONLY the JSON array.`;
             >
               Generate Daily Plan
             </Button>
-          </div>
-        ) : (
+          )}
+          size="lg"
+        />
+      ) : (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <h2 className="text-xl font-heading-semibold text-text-primary">
@@ -763,10 +755,36 @@ Focus on realistic timing and achievable goals. Return ONLY the JSON array.`;
             </div>
           </div>
         )}
-      </div>
 
       <FloatingActionButton />
-    </div>
+
+      <AddEventModal
+        isOpen={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        onAdd={(event) => {
+          // Map AddEventModal form { title, time, category, description, completed } to dayPlan item
+          addManualEvent({
+            id: Date.now(),
+            title: event.title,
+            time: event.time,
+            category: event.category,
+            description: event.description,
+            completed: false,
+            createdAt: new Date().toISOString(),
+          });
+        }}
+      />
+
+      <PreferencesModal
+        isOpen={showPreferences}
+        onClose={() => setShowPreferences(false)}
+        eventCount={eventCount}
+        setEventCount={setEventCount}
+        novelty={novelty}
+        setNovelty={setNovelty}
+        onDriftPlan={handleDriftPlan}
+      />
+    </Page>
   );
 };
 

--- a/src/pages/goals-dashboard/index.jsx
+++ b/src/pages/goals-dashboard/index.jsx
@@ -12,28 +12,35 @@ import WelcomeHero from './components/WelcomeHero';
 import QuickActions from './components/QuickActions';
 import FilterSortControls from './components/FilterSortControls';
 import GoalCard from './components/GoalCard';
-import EmptyState from './components/EmptyState';
+import DashboardEmptyState from './components/EmptyState';
 import Icon from '../../components/AppIcon';
+import Page from '../../components/ui/Page';
+import Button from '../../components/ui/Button';
+import SharedEmptyState from '../../components/ui/EmptyState';
+import Modal from '../../components/ui/Modal';
 import firestoreService from '../../services/firestoreService';
 
 // Onboarding Modal Component
 function OnboardingModal({ open, onClose }) {
-  if (!open) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-      <div className="bg-surface rounded-xl shadow-lg p-8 max-w-lg w-full relative">
-        <button className="absolute top-4 right-4 text-xl" onClick={onClose}>&times;</button>
-        <h2 className="text-2xl font-heading-bold mb-2">Welcome to Yaeger's Goals!</h2>
-        <p className="mb-4 text-text-secondary">Here's how to get started and make the most of your app:</p>
-        <ul className="list-disc pl-6 mb-4 text-text-primary">
-          <li><b>Install:</b> Just double-click the installer for Mac or Windows. No extra setup needed.</li>
-          <li><b>Getting Started:</b> Create your first goal to unlock achievements and analytics. Explore Focus Mode, Journal, and AI Assistant for more features.</li>
-          <li><b>What's New:</b> Enjoy a native desktop experience, auto-updates, and enhanced security with code signing.</li>
-        </ul>
-        <p className="text-xs text-text-secondary">You can always revisit this screen from the dashboard menu.</p>
-        <button className="mt-6 px-4 py-2 bg-primary text-white rounded" onClick={onClose}>Get Started</button>
-      </div>
-    </div>
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      title="Welcome to JustGoals!"
+      icon="Sparkles"
+      description="A quick tour of what you can do here."
+      size="lg"
+      footer={(
+        <Button variant="primary" onClick={onClose}>Get Started</Button>
+      )}
+    >
+      <ul className="list-disc pl-5 space-y-2 text-sm text-text-primary">
+        <li><span className="font-medium">Install:</span> Double-click the installer for Mac or Windows. No extra setup needed.</li>
+        <li><span className="font-medium">Getting started:</span> Create your first goal to unlock achievements and analytics. Explore Focus Mode, Journal, and the Drift AI assistant for more features.</li>
+        <li><span className="font-medium">What's new:</span> A native desktop experience, auto-updates, and enhanced security with code signing.</li>
+      </ul>
+      <p className="mt-4 text-xs text-text-muted">You can always revisit this screen from the dashboard menu.</p>
+    </Modal>
   );
 }
 
@@ -315,67 +322,79 @@ const GoalsDashboard = () => {
   // Always render the main dashboard layout
 
   return (
-    <div className="min-h-screen bg-background">
-      {showOnboarding && <OnboardingModal open={showOnboarding} onClose={handleDismissOnboarding} />}
+    <Page>
+      <OnboardingModal open={showOnboarding} onClose={handleDismissOnboarding} />
       {onboardingError && (
-        <div className="bg-error/10 border border-error/20 text-error text-center p-4 mb-4 rounded">
+        <div className="bg-error/10 border border-error/30 text-error text-center p-4 mb-4 rounded-xl">
           <strong>{onboardingError}</strong>
         </div>
       )}
       {updateStatus && (
-        <div className="bg-info text-info-content px-4 py-2 text-center">
+        <div className="bg-info/10 text-info border border-info/30 px-4 py-2 text-center mb-4 rounded-xl">
           {updateStatus}
         </div>
       )}
-      <main className="pt-20 pb-24 md:pb-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Welcome Hero Section - always show */}
-          <WelcomeHero
-            userName={displayUserStats.name}
-            userId={user?.id}
-            overallProgress={0} // If you have this value, pass it
-            totalGoals={displayUserStats.totalGoals}
-            completedGoals={displayUserStats.completedGoals}
-            streakDays={displayUserStats.streakDays}
-          />
-          {/* Quick Actions - always show */}
-          <QuickActions
-            onCreateGoal={handleCreateGoal}
-            onOpenDrift={handleOpenDrift}
-            onSmartPrioritize={handleSmartPrioritization}
-            hasGoals={safeGoals.length > 0}
-          />
-          {/* Filter and Sort Controls - always show */}
-          <FilterSortControls
-            onFilterChange={handleFilterChange}
-            onSortChange={handleSortChange}
-            activeFilter={activeFilter}
-            activeSort={activeSort}
-          />
-          {/* Goals Grid or Empty State */}
-          {Array.isArray(filteredGoals) && filteredGoals.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filteredGoals.map((goal) => (
-                <GoalCard
-                  key={goal.id}
-                  goal={goal}
-                  onGoalUpdate={handleGoalUpdate}
-                  onGoalDelete={handleDeleteGoal}
-                />
-              ))}
-            </div>
-          ) : (
-            <div className="text-center py-16">
-              <h1 className="text-2xl font-heading-bold text-text-primary mb-4">No Goals Yet</h1>
-              <p className="text-text-secondary mb-8">Start by creating your first goal to unlock achievements and progress tracking.</p>
-              <button onClick={handleCreateGoal} className="btn btn-primary">Create Goal</button>
-            </div>
-          )}
+
+      {/* Welcome Hero Section */}
+      <WelcomeHero
+        userName={displayUserStats.name}
+        userId={user?.id}
+        overallProgress={0}
+        totalGoals={displayUserStats.totalGoals}
+        completedGoals={displayUserStats.completedGoals}
+        streakDays={displayUserStats.streakDays}
+      />
+
+      {/* Quick Actions */}
+      <QuickActions
+        onCreateGoal={handleCreateGoal}
+        onOpenDrift={handleOpenDrift}
+        onSmartPrioritize={handleSmartPrioritization}
+        hasGoals={safeGoals.length > 0}
+      />
+
+      {/* Filter and Sort Controls */}
+      <FilterSortControls
+        onFilterChange={handleFilterChange}
+        onSortChange={handleSortChange}
+        activeFilter={activeFilter}
+        activeSort={activeSort}
+      />
+
+      {/* Goals Grid or Empty State */}
+      {Array.isArray(filteredGoals) && filteredGoals.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+          {filteredGoals.map((goal) => (
+            <GoalCard
+              key={goal.id}
+              goal={goal}
+              onGoalUpdate={handleGoalUpdate}
+              onGoalDelete={handleDeleteGoal}
+            />
+          ))}
         </div>
-      </main>
+      ) : (
+        <SharedEmptyState
+          icon="Target"
+          title="No goals yet"
+          description="Start by creating your first goal to unlock achievements and progress tracking."
+          action={(
+            <Button
+              variant="primary"
+              onClick={handleCreateGoal}
+              iconName="Plus"
+              iconPosition="left"
+            >
+              Create Goal
+            </Button>
+          )}
+          size="lg"
+        />
+      )}
+
       {/* Floating Action Button */}
       <FloatingActionButton />
-      
+
       {/* Smart Priority Manager Modal */}
       {showSmartPriority && (
         <SmartPriorityManager
@@ -385,7 +404,7 @@ const GoalsDashboard = () => {
           userContext={getUserContext()}
         />
       )}
-    </div>
+    </Page>
   );
 };
 

--- a/src/pages/habits/index.jsx
+++ b/src/pages/habits/index.jsx
@@ -3,7 +3,11 @@ import { useAuth } from '../../context/AuthContext';
 import { useAchievements } from '../../context/AchievementContext';
 import Icon from '../../components/ui/Icon';
 import Button from '../../components/ui/Button';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import EmptyState from '../../components/ui/EmptyState';
 import AddHabitModal from '../../components/AddHabitModal';
+import CreativeHabitsTree from '../../components/CreativeHabitsTree';
 import HabitsAIAssistant from './components/AIAssistantPanel';
 import habitService from '../../services/habitService';
 
@@ -224,35 +228,32 @@ const HabitsPage = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="text-center">
-          <Icon name="Loader" className="w-8 h-8 animate-spin mx-auto mb-4 text-primary" />
+      <Page>
+        <div className="flex flex-col items-center justify-center py-20">
+          <Icon name="Loader" className="w-8 h-8 animate-spin mb-3 text-primary" />
           <p className="text-text-secondary">Loading habits...</p>
         </div>
-      </div>
+      </Page>
     );
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="max-w-4xl mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h1 className="text-3xl font-heading-bold text-text-primary mb-2">Habits</h1>
-            <p className="text-text-secondary">Build lasting habits with unified tree tracking</p>
-          </div>
-          <div className="flex items-center space-x-3">
-            
+    <Page width="lg">
+      <PageHeader
+        icon="Repeat"
+        title="Habits"
+        subtitle="Build lasting habits with unified tree tracking"
+        actions={(
+          <>
             <Button
               onClick={() => setShowAIAssistant(!showAIAssistant)}
               variant="secondary"
               size="sm"
+              iconName="Bot"
+              iconPosition="left"
             >
-              <Icon name="Bot" size={16} className="mr-1" />
               AI Assistant
             </Button>
-            
             <Button
               onClick={() => setShowAddModal(true)}
               iconName="Plus"
@@ -260,17 +261,17 @@ const HabitsPage = () => {
             >
               Add Habit
             </Button>
-          </div>
-        </div>
+          </>
+        )}
+      />
 
-        {/* Main Content Area */}
-        {habits.length === 0 ? (
-          <div className="text-center py-12">
-            <Icon name="Target" className="w-16 h-16 mx-auto mb-4 text-text-secondary" />
-            <h3 className="text-xl font-semibold text-text-primary mb-2">No habits yet</h3>
-            <p className="text-text-secondary mb-6">
-              Start building positive habits with our unified tree tracking system
-            </p>
+      {/* Main Content Area */}
+      {habits.length === 0 ? (
+        <EmptyState
+          icon="Repeat"
+          title="No habits yet"
+          description="Start building positive habits with our unified tree tracking system."
+          action={(
             <Button
               onClick={() => setShowAddModal(true)}
               iconName="Plus"
@@ -278,17 +279,18 @@ const HabitsPage = () => {
             >
               Create Your First Habit
             </Button>
-          </div>
-        ) : (
-          /* Creative Tree Visualization */
-          <CreativeHabitsTree 
-            habits={habits}
-            onCheckIn={handleCheckIn}
-            onEditHabit={handleEditHabit}
-            onDeleteHabit={handleDeleteHabit}
-          />
-        )}
-      </div>
+          )}
+          size="lg"
+        />
+      ) : (
+        /* Creative Tree Visualization */
+        <CreativeHabitsTree
+          habits={habits}
+          onCheckIn={handleCheckIn}
+          onEditHabit={handleEditHabit}
+          onDeleteHabit={handleDeleteHabit}
+        />
+      )}
 
       {/* Add Habit Modal */}
       {showAddModal && (
@@ -322,7 +324,7 @@ const HabitsPage = () => {
         onUpdateHabit={handleUpdateHabit}
         onDeleteHabit={handleDeleteHabit}
       />
-    </div>
+    </Page>
   );
 };
 

--- a/src/pages/journal/index.jsx
+++ b/src/pages/journal/index.jsx
@@ -6,6 +6,11 @@ import * as entityService from '../../services/entityManagementService'; // Impo
 import Icon from '../../components/AppIcon';
 import Button from '../../components/ui/Button';
 import FloatingActionButton from '../../components/ui/FloatingActionButton';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import StatCard from '../../components/ui/StatCard';
+import Card from '../../components/ui/Card';
+import EmptyState from '../../components/ui/EmptyState';
 import JournalEntry from './components/JournalEntry';
 import JournalEditor from './components/JournalEditor';
 import AIInsightsPanel from './components/AIInsightsPanel';
@@ -220,207 +225,164 @@ const Journal = () => {
   const safeFilteredEntries = Array.isArray(filteredEntries) ? filteredEntries : [];
   const safeGoals = Array.isArray(goals) ? goals : [];
 
+  const thisMonthCount = safeEntries.filter(entry => {
+    const entryDate = new Date(entry.date);
+    const now = new Date();
+    return entryDate.getMonth() === now.getMonth() &&
+      entryDate.getFullYear() === now.getFullYear();
+  }).length;
+
   return (
-    <div className="min-h-screen bg-background">
-      
-      <main className="pt-20 pb-24 md:pb-8">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Header Section */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="mb-8"
+    <Page width="lg">
+      <PageHeader
+        icon="BookOpen"
+        title="Daily Journal"
+        subtitle="Reflect on your progress, thoughts, and experiences"
+        actions={(
+          <>
+            <div className="flex items-center gap-2 px-3 py-1.5 bg-gradient-to-r from-primary/10 to-secondary/10 rounded-lg border border-primary/20">
+              <Icon name="Flame" size={16} className="text-warning" />
+              <span className="text-sm font-medium text-text-primary">
+                {streakDays} day streak
+              </span>
+            </div>
+            <Button
+              variant="primary"
+              onClick={() => setIsEditorOpen(true)}
+              iconName="Plus"
+              iconPosition="left"
+            >
+              New Entry
+            </Button>
+          </>
+        )}
+      />
+
+      {/* Stats Row */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 mb-6">
+        <StatCard
+          icon="BookOpen"
+          label="Total Entries"
+          value={safeEntries.length}
+          tone="primary"
+        />
+        <StatCard
+          icon="Calendar"
+          label="This Month"
+          value={thisMonthCount}
+          tone="accent"
+        />
+        <StatCard
+          icon="Smile"
+          label="Avg Mood"
+          value={safeEntries.length > 0 ? getMoodEmoji(safeEntries[0]?.mood || 'okay') : '😐'}
+          tone="secondary"
+        />
+        <Card padding="md" className="flex items-center">
+          <Button
+            variant="ghost"
+            onClick={handleGenerateInsights}
+            disabled={safeEntries.length === 0 || isLoadingInsights}
+            loading={isLoadingInsights}
+            iconName="Brain"
+            iconPosition="left"
+            className="w-full justify-start"
           >
-            <div className="flex items-center justify-between mb-6">
-              <div>
-                <h1 className="text-3xl font-heading-bold text-text-primary mb-2">
-                  Daily Journal
-                </h1>
-                <p className="text-text-secondary">
-                  Reflect on your progress, thoughts, and experiences
-                </p>
-              </div>
-              
-              <div className="flex items-center space-x-4">
-                {/* Streak Counter */}
-                <motion.div
-                  initial={{ scale: 0.9 }}
-                  animate={{ scale: 1 }}
-                  className="flex items-center space-x-2 bg-gradient-to-r from-primary/20 to-secondary/20 rounded-lg px-4 py-2 border border-primary/30"
-                >
-                  <Icon name="Flame" size={16} className="text-warning" />
-                  <span className="text-sm font-medium text-text-primary">
-                    {streakDays} day streak
-                  </span>
-                </motion.div>
-                
-                <Button
-                  variant="primary"
-                  onClick={() => setIsEditorOpen(true)}
-                  iconName="Plus"
-                  iconPosition="left"
-                  className="shadow-lg hover:shadow-xl transition-shadow"
-                >
-                  New Entry
-                </Button>
-              </div>
-            </div>
+            AI Insights
+          </Button>
+        </Card>
+      </div>
 
-            {/* Stats Row */}
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-              <motion.div
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                className="bg-surface rounded-lg p-4 border border-border"
-              >
-                <div className="flex items-center space-x-2">
-                  <Icon name="BookOpen" size={20} className="text-primary" />
-                  <span className="text-sm text-text-secondary">Total Entries</span>
-                </div>
-                <div className="text-2xl font-heading-semibold text-text-primary mt-1">
-                  {safeEntries.length}
-                </div>
-              </motion.div>
-              
-              <motion.div
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.1 }}
-                className="bg-surface rounded-lg p-4 border border-border"
-              >
-                <div className="flex items-center space-x-2">
-                  <Icon name="Calendar" size={20} className="text-accent" />
-                  <span className="text-sm text-text-secondary">This Month</span>
-                </div>
-                <div className="text-2xl font-heading-semibold text-text-primary mt-1">
-                  {safeEntries.filter(entry => {
-                    const entryDate = new Date(entry.date);
-                    const now = new Date();
-                    return entryDate.getMonth() === now.getMonth() && 
-                           entryDate.getFullYear() === now.getFullYear();
-                  }).length}
-                </div>
-              </motion.div>
-              
-              <motion.div
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.2 }}
-                className="bg-surface rounded-lg p-4 border border-border"
-              >
-                <div className="flex items-center space-x-2">
-                  <Icon name="Smile" size={20} className="text-secondary" />
-                  <span className="text-sm text-text-secondary">Avg Mood</span>
-                </div>
-                <div className="text-2xl font-heading-semibold text-text-primary mt-1">
-                  {safeEntries.length > 0 ? getMoodEmoji(safeEntries[0]?.mood || 'okay') : '😐'}
-                </div>
-              </motion.div>
-              
-              <motion.div
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.3 }}
-                className="bg-surface rounded-lg p-4 border border-border"
-              >
-                <Button
-                  variant="ghost"
-                  onClick={handleGenerateInsights}
-                  disabled={safeEntries.length === 0 || isLoadingInsights}
-                  loading={isLoadingInsights}
-                  iconName="Brain"
-                  iconPosition="left"
-                  className="w-full justify-start"
-                >
-                  AI Insights
-                </Button>
-              </motion.div>
-            </div>
-          </motion.div>
+      {/* Search and Filter */}
+      <SearchFilter
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        selectedMood={selectedMood}
+        onMoodChange={setSelectedMood}
+        selectedGoal={selectedGoal}
+        onGoalChange={setSelectedGoal}
+        goals={safeGoals}
+      />
 
-          {/* Search and Filter */}
-          <SearchFilter
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            selectedMood={selectedMood}
-            onMoodChange={setSelectedMood}
-            selectedGoal={selectedGoal}
-            onGoalChange={setSelectedGoal}
-            goals={safeGoals}
-          />
-
-          {/* Journal Entries */}
-          {error && (
-            <div className="p-4 bg-error/10 border border-error/20 rounded text-error text-center mb-4">{error}</div>
-          )}
-          {safeFilteredEntries.length > 0 ? (
-            <AnimatePresence mode="wait">
-              {safeFilteredEntries.map((entry, index) => (
-                <motion.div
-                  key={entry.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.1 }}
-                >
-                  <JournalEntry
-                    entry={entry}
-                    onEdit={handleEditEntry}
-                    onDelete={handleDeleteEntry}
-                    goals={safeGoals}
-                  />
-                </motion.div>
-              ))}
-            </AnimatePresence>
-          ) : (
-            <div className="text-center py-8 text-text-secondary">
-              <Icon name="BookOpen" size={48} className="mx-auto mb-4 opacity-50" />
-              <p>No journal entries found. Start by adding a new entry!</p>
-            </div>
-          )}
-
-          {/* Quick Actions */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="mt-8 bg-surface rounded-lg border border-border p-6"
-          >
-            <h3 className="font-heading-medium text-text-primary mb-4">Quick Actions</h3>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <Link
-                to="/goals-dashboard"
-                className="flex flex-col items-center p-4 rounded-lg hover:bg-surface-700 transition-colors"
+      {/* Journal Entries */}
+      {error && (
+        <div className="p-4 bg-error/10 border border-error/20 rounded-xl text-error text-center mb-4">{error}</div>
+      )}
+      {safeFilteredEntries.length > 0 ? (
+        <div className="space-y-4">
+          <AnimatePresence mode="wait">
+            {safeFilteredEntries.map((entry, index) => (
+              <motion.div
+                key={entry.id}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.05 }}
               >
-                <Icon name="Target" size={24} className="text-primary mb-2" />
-                <span className="text-sm text-text-secondary">Goals</span>
-              </Link>
-              
-              <Link
-                to="/focus-mode"
-                className="flex flex-col items-center p-4 rounded-lg hover:bg-surface-700 transition-colors"
-              >
-                <Icon name="Focus" size={24} className="text-accent mb-2" />
-                <span className="text-sm text-text-secondary">Focus Mode</span>
-              </Link>
-              
-              <Link
-                to="/ai-assistant-chat-drift"
-                className="flex flex-col items-center p-4 rounded-lg hover:bg-surface-700 transition-colors"
-              >
-                <Icon name="Bot" size={24} className="text-secondary mb-2" />
-                <span className="text-sm text-text-secondary">Chat with Drift</span>
-              </Link>
-              
-              <Link
-                to="/daily-milestones"
-                className="flex flex-col items-center p-4 rounded-lg hover:bg-surface-700 transition-colors"
-              >
-                <Icon name="CheckSquare" size={24} className="text-warning mb-2" />
-                <span className="text-sm text-text-secondary">Milestones</span>
-              </Link>
-            </div>
-          </motion.div>
+                <JournalEntry
+                  entry={entry}
+                  onEdit={handleEditEntry}
+                  onDelete={handleDeleteEntry}
+                  goals={safeGoals}
+                />
+              </motion.div>
+            ))}
+          </AnimatePresence>
         </div>
-      </main>
+      ) : (
+        <EmptyState
+          icon="BookOpen"
+          title="No journal entries found"
+          description="Start by adding a new entry to capture your day."
+          action={(
+            <Button
+              variant="primary"
+              onClick={() => setIsEditorOpen(true)}
+              iconName="Plus"
+              iconPosition="left"
+            >
+              New Entry
+            </Button>
+          )}
+        />
+      )}
+
+      {/* Quick Actions */}
+      <Card padding="lg" className="mt-8">
+        <h3 className="font-heading-medium text-text-primary mb-4">Quick Actions</h3>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Link
+            to="/goals-dashboard"
+            className="flex flex-col items-center p-4 rounded-xl border border-border hover:border-primary/40 hover:bg-primary/5 transition-all"
+          >
+            <Icon name="Target" size={24} className="text-primary mb-2" />
+            <span className="text-sm text-text-secondary">Goals</span>
+          </Link>
+
+          <Link
+            to="/focus-mode"
+            className="flex flex-col items-center p-4 rounded-xl border border-border hover:border-accent/40 hover:bg-accent/5 transition-all"
+          >
+            <Icon name="Zap" size={24} className="text-accent mb-2" />
+            <span className="text-sm text-text-secondary">Focus Mode</span>
+          </Link>
+
+          <Link
+            to="/ai-assistant-chat-drift"
+            className="flex flex-col items-center p-4 rounded-xl border border-border hover:border-secondary/40 hover:bg-secondary/5 transition-all"
+          >
+            <Icon name="Bot" size={24} className="text-secondary mb-2" />
+            <span className="text-sm text-text-secondary">Chat with Drift</span>
+          </Link>
+
+          <Link
+            to="/progress"
+            className="flex flex-col items-center p-4 rounded-xl border border-border hover:border-warning/40 hover:bg-warning/5 transition-all"
+          >
+            <Icon name="CheckSquare" size={24} className="text-warning mb-2" />
+            <span className="text-sm text-text-secondary">Milestones</span>
+          </Link>
+        </div>
+      </Card>
 
       {/* Floating Action Button */}
       <FloatingActionButton />
@@ -444,7 +406,7 @@ const Journal = () => {
         insights={aiInsights}
         isLoading={isLoadingInsights}
       />
-    </div>
+    </Page>
   );
 };
 

--- a/src/pages/meals/index.jsx
+++ b/src/pages/meals/index.jsx
@@ -5,6 +5,11 @@ import { useSettings } from '../../context/SettingsContext';
 import { useMeals } from '../../context/MealsContext';
 import { useAchievements } from '../../context/AchievementContext';
 import Icon from '../../components/ui/Icon';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import StatCard from '../../components/ui/StatCard';
+import TabBar from '../../components/ui/TabBar';
+import EmptyState from '../../components/ui/EmptyState';
 import MealPlanView from './components/MealPlanView';
 import MealPreferences from './components/MealPreferences';
 import AIAssistantPanel from './components/AIAssistantPanel';
@@ -12,14 +17,14 @@ import AIAssistantPanel from './components/AIAssistantPanel';
 const MealsPage = () => {
   const { user } = useAuth();
   const { settings } = useSettings();
-  const { 
-    meals, 
-    mealPlans, 
-    mealPreferences, 
-    loading, 
+  const {
+    meals,
+    mealPlans,
+    mealPreferences,
+    loading,
     error,
     getCurrentWeekMealPlan,
-    loadUserMealData 
+    loadUserMealData
   } = useMeals();
   const { addAchievement } = useAchievements();
 
@@ -45,136 +50,108 @@ const MealsPage = () => {
 
   if (!user?.uid) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="text-center">
-          <Icon name="AlertCircle" className="w-16 h-16 mx-auto text-error mb-4" />
-          <h3 className="text-xl font-semibold text-text-primary mb-2">Sign In Required</h3>
-          <p className="text-text-secondary">Please sign in to access your meal plans.</p>
-        </div>
-      </div>
+      <Page>
+        <EmptyState
+          icon="LogIn"
+          title="Sign In Required"
+          description="Please sign in to access your meal plans."
+          size="lg"
+        />
+      </Page>
     );
   }
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="text-center">
-          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+      <Page>
+        <div className="flex flex-col items-center justify-center py-20">
+          <div className="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin mb-4"></div>
           <p className="text-text-secondary">Loading your meal data...</p>
         </div>
-      </div>
+      </Page>
     );
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center space-x-3 mb-4">
-            <div className="w-12 h-12 bg-gradient-to-br from-primary to-secondary rounded-lg flex items-center justify-center">
-              <Icon name="UtensilsCrossed" className="w-7 h-7 text-white" />
-            </div>
-            <div>
-              <h1 className="text-3xl font-heading-bold text-text-primary">Meals</h1>
-              <p className="text-text-secondary">Plan and track your macro-optimized meals</p>
-            </div>
-          </div>
+    <Page>
+      <PageHeader
+        icon="UtensilsCrossed"
+        title="Meals"
+        subtitle="Plan and track your macro-optimized meals"
+      />
 
-          {/* Quick Stats */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-            <div className="bg-surface border border-border rounded-lg p-4">
-              <div className="flex items-center space-x-2">
-                <Icon name="Target" className="w-5 h-5 text-primary" />
-                <span className="text-sm font-medium text-text-secondary">Daily Goal</span>
-              </div>
-              <p className="text-2xl font-bold text-text-primary">{mealPreferences.dailyCalories}</p>
-              <p className="text-xs text-text-secondary">calories</p>
-            </div>
-            
-            <div className="bg-surface border border-border rounded-lg p-4">
-              <div className="flex items-center space-x-2">
-                <Icon name="Activity" className="w-5 h-5 text-green-500" />
-                <span className="text-sm font-medium text-text-secondary">Protein</span>
-              </div>
-              <p className="text-2xl font-bold text-text-primary">{mealPreferences.macroTargets.protein}%</p>
-              <p className="text-xs text-text-secondary">target</p>
-            </div>
+      {/* Quick Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 mb-6">
+        <StatCard
+          icon="Target"
+          label="Daily Goal"
+          value={mealPreferences.dailyCalories}
+          sublabel="calories"
+          tone="primary"
+        />
+        <StatCard
+          icon="Activity"
+          label="Protein"
+          value={`${mealPreferences.macroTargets.protein}%`}
+          sublabel="target"
+          tone="success"
+        />
+        <StatCard
+          icon="Zap"
+          label="Carbs"
+          value={`${mealPreferences.macroTargets.carbs}%`}
+          sublabel="target"
+          tone="warning"
+        />
+        <StatCard
+          icon="Droplets"
+          label="Fat"
+          value={`${mealPreferences.macroTargets.fat}%`}
+          sublabel="target"
+          tone="info"
+        />
+      </div>
 
-            <div className="bg-surface border border-border rounded-lg p-4">
-              <div className="flex items-center space-x-2">
-                <Icon name="Zap" className="w-5 h-5 text-yellow-500" />
-                <span className="text-sm font-medium text-text-secondary">Carbs</span>
-              </div>
-              <p className="text-2xl font-bold text-text-primary">{mealPreferences.macroTargets.carbs}%</p>
-              <p className="text-xs text-text-secondary">target</p>
-            </div>
+      {/* Tab Navigation */}
+      <div className="mb-6">
+        <TabBar tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
+      </div>
 
-            <div className="bg-surface border border-border rounded-lg p-4">
-              <div className="flex items-center space-x-2">
-                <Icon name="Droplets" className="w-5 h-5 text-blue-500" />
-                <span className="text-sm font-medium text-text-secondary">Fat</span>
-              </div>
-              <p className="text-2xl font-bold text-text-primary">{mealPreferences.macroTargets.fat}%</p>
-              <p className="text-xs text-text-secondary">target</p>
-            </div>
-          </div>
-
-          {/* Tab Navigation */}
-          <div className="flex space-x-1 bg-surface border border-border rounded-lg p-1">
-            {tabs.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`flex items-center space-x-2 px-4 py-2 rounded-md font-medium transition-all duration-200 ${
-                  activeTab === tab.id
-                    ? 'bg-primary text-white shadow-sm'
-                    : 'text-text-secondary hover:text-text-primary hover:bg-surface-700'
-                }`}
-              >
-                <Icon name={tab.icon} className="w-4 h-4" />
-                <span>{tab.label}</span>
-              </button>
-            ))}
+      {/* Error Display */}
+      {error && (
+        <div className="mb-6 p-4 bg-error/10 border border-error/30 rounded-xl">
+          <div className="flex items-center space-x-2">
+            <Icon name="AlertCircle" className="w-5 h-5 text-error" />
+            <p className="text-error">{error}</p>
           </div>
         </div>
+      )}
 
-        {/* Error Display */}
-        {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
-            <div className="flex items-center space-x-2">
-              <Icon name="AlertCircle" className="w-5 h-5 text-red-500" />
-              <p className="text-red-700">{error}</p>
-            </div>
-          </div>
-        )}
+      {/* Tab Content */}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeTab}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.2 }}
+        >
+          {activeTab === 'plan' && (
+            <MealPlanView currentWeekPlan={currentWeekPlan} mealPreferences={mealPreferences} setActiveTab={setActiveTab} />
+          )}
 
-        {/* Tab Content */}
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={activeTab}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -20 }}
-            transition={{ duration: 0.3 }}
-          >
-            {activeTab === 'plan' && (
-              <MealPlanView currentWeekPlan={currentWeekPlan} mealPreferences={mealPreferences} setActiveTab={setActiveTab} />
-            )}
-            
-            {activeTab === 'preferences' && (
-              <MealPreferences 
-                preferences={mealPreferences}
-              />
-            )}
-            
-            {activeTab === 'ai' && (
-              <AIAssistantPanel mealData={{ meals, mealPlans, mealPreferences }} apiKey={settings.geminiApiKey} />
-            )}
-          </motion.div>
-        </AnimatePresence>
-      </div>
-    </div>
+          {activeTab === 'preferences' && (
+            <MealPreferences
+              preferences={mealPreferences}
+            />
+          )}
+
+          {activeTab === 'ai' && (
+            <AIAssistantPanel mealData={{ meals, mealPlans, mealPreferences }} apiKey={settings.geminiApiKey} />
+          )}
+        </motion.div>
+      </AnimatePresence>
+    </Page>
   );
 };
 

--- a/src/pages/progress/index.jsx
+++ b/src/pages/progress/index.jsx
@@ -6,6 +6,10 @@ import { calculateUserStreak } from '../../utils/goalUtils'; // Import streak ca
 import Icon from '../../components/AppIcon';
 import Button from '../../components/ui/Button';
 import FloatingActionButton from '../../components/ui/FloatingActionButton';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import Card from '../../components/ui/Card';
+import EmptyState from '../../components/ui/EmptyState';
 
 // Import all components
 import MilestoneCard from './components/MilestoneCard';
@@ -305,12 +309,15 @@ const Progress = () => {
   const safeActiveProgressData = Array.isArray(activeProgressData) ? activeProgressData : [];
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="pt-16 pb-20 md:pb-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-col lg:flex-row gap-6">
-            {/* Main Content */}
-            <div className="flex-1 space-y-6">
+    <Page>
+      <PageHeader
+        icon="TrendingUp"
+        title="Progress"
+        subtitle="Track milestones and visualize your journey toward each goal"
+      />
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Main Content */}
+        <div className="flex-1 space-y-6">
               {/* Date Header */}
               <DateHeader
                 selectedDate={selectedDate}
@@ -335,7 +342,7 @@ const Progress = () => {
               />
 
               {/* Toggle between AI and Manual Mode */}
-              <div className="flex items-center justify-between p-4 bg-surface rounded-lg border border-border">
+              <div className="flex items-center justify-between p-4 bg-surface rounded-xl border border-border">
                 <div className="flex items-center space-x-3">
                   <Icon name="Bot" size={20} className="text-primary" />
                   <div>
@@ -389,28 +396,24 @@ const Progress = () => {
                 )}
 
                 {safeActiveProgressData.length === 0 ? (
-                  <div className="text-center py-12">
-                    <div className="w-16 h-16 bg-surface-700 rounded-full flex items-center justify-center mx-auto mb-4">
-                      <Icon name="Target" size={24} className="text-text-secondary" />
-                    </div>
-                    <h3 className="text-lg font-heading-medium text-text-primary mb-2">
-                      {useAIJourney ? 'Generate Your AI Progress Journey' : 'Start Your Progress Journey'}
-                    </h3>
-                    <p className="text-text-secondary mb-4">
-                      {useAIJourney 
-                        ? 'Let AI analyze your patterns and create personalized milestones'
-                        : 'Create progression marks to track your journey toward your goals'
-                      }
-                    </p>
-                    <Button
-                      variant="primary"
-                      onClick={() => useAIJourney ? null : setIsAddModalOpen(true)}
-                      iconName={useAIJourney ? "Bot" : "Plus"}
-                      iconPosition="left"
-                    >
-                      {useAIJourney ? 'AI will auto-generate when you select a goal' : 'Add Progress Step'}
-                    </Button>
-                  </div>
+                  <EmptyState
+                    icon="Target"
+                    title={useAIJourney ? 'Generate Your AI Progress Journey' : 'Start Your Progress Journey'}
+                    description={useAIJourney
+                      ? 'Let AI analyze your patterns and create personalized milestones.'
+                      : 'Create progression marks to track your journey toward your goals.'}
+                    action={(
+                      <Button
+                        variant="primary"
+                        onClick={() => useAIJourney ? null : setIsAddModalOpen(true)}
+                        iconName={useAIJourney ? 'Bot' : 'Plus'}
+                        iconPosition="left"
+                      >
+                        {useAIJourney ? 'AI will auto-generate when you select a goal' : 'Add Progress Step'}
+                      </Button>
+                    )}
+                    size="md"
+                  />
                 ) : (
                   <div className="space-y-3">
                     {safeActiveProgressData.map((milestone) => (
@@ -432,12 +435,12 @@ const Progress = () => {
               </div>
 
               {/* Quick Actions */}
-              <div className="bg-surface rounded-lg border border-border p-4">
+              <Card padding="md">
                 <h3 className="font-heading-medium text-text-primary mb-3">Quick Actions</h3>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                   <Link
                     to="/focus-mode"
-                    className="flex flex-col items-center p-3 rounded-lg hover:bg-surface-700 transition-colors duration-fast"
+                    className="flex flex-col items-center p-3 rounded-lg hover:bg-surface-700/40 transition-colors duration-fast"
                   >
                     <Icon name="Focus" size={20} className="text-primary mb-2" />
                     <span className="text-xs font-caption text-text-secondary">Focus Mode</span>
@@ -445,7 +448,7 @@ const Progress = () => {
                   
                   <Link
                     to="/goals-dashboard"
-                    className="flex flex-col items-center p-3 rounded-lg hover:bg-surface-700 transition-colors duration-fast"
+                    className="flex flex-col items-center p-3 rounded-lg hover:bg-surface-700/40 transition-colors duration-fast"
                   >
                     <Icon name="Target" size={20} className="text-accent mb-2" />
                     <span className="text-xs font-caption text-text-secondary">Goals</span>
@@ -453,7 +456,7 @@ const Progress = () => {
                   
                   <button
                     onClick={() => setIsAIExpanded(true)}
-                    className="flex flex-col items-center p-3 rounded-lg hover:bg-surface-700 transition-colors duration-fast"
+                    className="flex flex-col items-center p-3 rounded-lg hover:bg-surface-700/40 transition-colors duration-fast"
                   >
                     <Icon name="Bot" size={20} className="text-secondary mb-2" />
                     <span className="text-xs font-caption text-text-secondary">
@@ -463,26 +466,24 @@ const Progress = () => {
                   
                   <Link
                     to="/settings-configuration"
-                    className="flex flex-col items-center p-3 rounded-lg hover:bg-surface-700 transition-colors duration-fast"
+                    className="flex flex-col items-center p-3 rounded-lg hover:bg-surface-700/40 transition-colors duration-fast"
                   >
                     <Icon name="Settings" size={20} className="text-warning mb-2" />
                     <span className="text-xs font-caption text-text-secondary">Settings</span>
                   </Link>
                 </div>
-              </div>
-            </div>
+              </Card>
+        </div>
 
-            {/* Progress AI Assistant Panel - Desktop */}
-            <div className="hidden lg:block">
-              <ProgressAIAssistant
-                isExpanded={isAIExpanded}
-                onToggle={() => setIsAIExpanded(!isAIExpanded)}
-                selectedGoal={selectedGoal}
-                progressMarks={safeActiveProgressData}
-                onCreateProgressPath={handleCreateProgressPath}
-              />
-            </div>
-          </div>
+        {/* Progress AI Assistant Panel - Desktop */}
+        <div className="hidden lg:block">
+          <ProgressAIAssistant
+            isExpanded={isAIExpanded}
+            onToggle={() => setIsAIExpanded(!isAIExpanded)}
+            selectedGoal={selectedGoal}
+            progressMarks={safeActiveProgressData}
+            onCreateProgressPath={handleCreateProgressPath}
+          />
         </div>
       </div>
 
@@ -520,7 +521,7 @@ const Progress = () => {
         totalMilestones={totalCount}
         onSaveReflection={handleSaveReflection}
       />
-    </div>
+    </Page>
   );
 };
 

--- a/src/pages/settings-configuration/index.jsx
+++ b/src/pages/settings-configuration/index.jsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import { useSettings } from '../../context/SettingsContext';
 import Icon from '../../components/ui/Icon';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import Card from '../../components/ui/Card';
 import ProfileSection from './components/ProfileSection';
 import ApiKeySection from './components/ApiKeySection';
 import NotificationSection from './components/NotificationSection';
@@ -50,109 +53,107 @@ const SettingsPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background transition-colors duration-200" style={{ scrollBehavior: 'smooth' }}>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        {/* Header - Fixed height to prevent shift */}
-        <div className="mb-8 min-h-[80px]">
-          <h1 className="text-3xl font-heading-bold text-text-primary mb-2 transition-colors duration-200">Settings</h1>
-          <p className="text-text-secondary transition-colors duration-200">Customize your JustGoals experience</p>
-        </div>
+    <Page>
+      <PageHeader
+        icon="Settings"
+        title="Settings"
+        subtitle="Customize your JustGoals experience"
+      />
 
-        <div className="flex flex-col lg:flex-row gap-6">
-          {/* Sidebar Navigation */}
-          <div className={`lg:w-64 ${isMobile ? 'order-2' : 'order-1'}`}>
-            <div className="bg-surface rounded-lg border border-border p-4 transition-colors duration-200">
-              <h2 className="text-lg font-heading-semibold text-text-primary mb-4 transition-colors duration-200">Categories</h2>
-              
-              {isMobile ? (
-                // Mobile: Horizontal scrollable tabs
-                <div
-                  className="flex space-x-2 overflow-x-auto pb-2"
-                  role="tablist"
-                  aria-label="Settings Categories"
-                  onKeyDown={e => {
-                    if (["ArrowLeft", "ArrowRight"].includes(e.key)) {
-                      e.preventDefault();
-                      const idx = sections.findIndex(s => s.id === activeSection);
-                      let nextIdx = e.key === "ArrowLeft" ? idx - 1 : idx + 1;
-                      if (nextIdx < 0) nextIdx = sections.length - 1;
-                      if (nextIdx >= sections.length) nextIdx = 0;
-                      setActiveSection(sections[nextIdx].id);
-                      document.getElementById(`settings-tab-${sections[nextIdx].id}`)?.focus();
-                    }
-                  }}
-                >
-                  {sections.map((section) => (
-                    <button
-                      key={section.id}
-                      id={`settings-tab-${section.id}`}
-                      onClick={() => setActiveSection(section.id)}
-                      className={`flex items-center space-x-2 px-3 py-2 rounded-lg whitespace-nowrap transition-all duration-200 ${
-                        activeSection === section.id
-                          ? 'bg-primary text-white shadow-lg'
-                          : 'text-text-secondary hover:text-text-primary hover:bg-surface-700'
-                      }`}
-                      role="tab"
-                      aria-selected={activeSection === section.id}
-                      aria-controls={`settings-tabpanel-${section.id}`}
-                      tabIndex={activeSection === section.id ? 0 : -1}
-                    >
-                      <Icon name={section.icon} className="w-4 h-4" />
-                      <span className="text-sm font-medium">{section.label}</span>
-                    </button>
-                  ))}
-                </div>
-              ) : (
-                // Desktop: Vertical sidebar
-                <nav
-                  className="space-y-1"
-                  role="tablist"
-                  aria-label="Settings Categories"
-                  onKeyDown={e => {
-                    if (["ArrowUp", "ArrowDown"].includes(e.key)) {
-                      e.preventDefault();
-                      const idx = sections.findIndex(s => s.id === activeSection);
-                      let nextIdx = e.key === "ArrowUp" ? idx - 1 : idx + 1;
-                      if (nextIdx < 0) nextIdx = sections.length - 1;
-                      if (nextIdx >= sections.length) nextIdx = 0;
-                      setActiveSection(sections[nextIdx].id);
-                      document.getElementById(`settings-tab-${sections[nextIdx].id}`)?.focus();
-                    }
-                  }}
-                >
-                  {sections.map((section) => (
-                    <button
-                      key={section.id}
-                      id={`settings-tab-${section.id}`}
-                      onClick={() => setActiveSection(section.id)}
-                      className={`flex items-center space-x-2 px-3 py-2 rounded-lg whitespace-nowrap transition-all duration-200 ${
-                        activeSection === section.id
-                          ? 'bg-primary text-white shadow-lg'
-                          : 'text-text-secondary hover:text-text-primary hover:bg-surface-700'
-                      }`}
-                      role="tab"
-                      aria-selected={activeSection === section.id}
-                      aria-controls={`settings-tabpanel-${section.id}`}
-                      tabIndex={activeSection === section.id ? 0 : -1}
-                    >
-                      <Icon name={section.icon} className="w-4 h-4" />
-                      <span className="text-sm font-medium">{section.label}</span>
-                    </button>
-                  ))}
-                </nav>
-              )}
-            </div>
-          </div>
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Sidebar Navigation */}
+        <aside className={`lg:w-60 flex-shrink-0 ${isMobile ? 'order-2' : 'order-1'}`}>
+          <Card padding="md">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-text-muted mb-3 px-1">
+              Categories
+            </h2>
 
-          {/* Main Content - Enhanced stabilization */}
-          <div className="flex-1 min-h-[600px] transition-all duration-200" style={{ contain: 'layout' }}>
-            <div className="min-h-full">
-              {renderSection()}
-            </div>
-          </div>
-        </div>
+            {isMobile ? (
+              // Mobile: Horizontal scrollable tabs
+              <div
+                className="flex space-x-2 overflow-x-auto pb-2"
+                role="tablist"
+                aria-label="Settings Categories"
+                onKeyDown={(e) => {
+                  if (["ArrowLeft", "ArrowRight"].includes(e.key)) {
+                    e.preventDefault();
+                    const idx = sections.findIndex((s) => s.id === activeSection);
+                    let nextIdx = e.key === "ArrowLeft" ? idx - 1 : idx + 1;
+                    if (nextIdx < 0) nextIdx = sections.length - 1;
+                    if (nextIdx >= sections.length) nextIdx = 0;
+                    setActiveSection(sections[nextIdx].id);
+                    document.getElementById(`settings-tab-${sections[nextIdx].id}`)?.focus();
+                  }
+                }}
+              >
+                {sections.map((section) => (
+                  <button
+                    key={section.id}
+                    id={`settings-tab-${section.id}`}
+                    onClick={() => setActiveSection(section.id)}
+                    className={`flex items-center space-x-2 px-3 py-2 rounded-lg whitespace-nowrap text-sm font-medium transition-all duration-200 ${
+                      activeSection === section.id
+                        ? 'bg-gradient-to-r from-primary to-secondary text-white shadow-md shadow-primary/20'
+                        : 'text-text-secondary hover:text-text-primary hover:bg-surface-700/40'
+                    }`}
+                    role="tab"
+                    aria-selected={activeSection === section.id}
+                    aria-controls={`settings-tabpanel-${section.id}`}
+                    tabIndex={activeSection === section.id ? 0 : -1}
+                  >
+                    <Icon name={section.icon} className="w-4 h-4" />
+                    <span>{section.label}</span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              // Desktop: Vertical sidebar
+              <nav
+                className="space-y-1"
+                role="tablist"
+                aria-label="Settings Categories"
+                onKeyDown={(e) => {
+                  if (["ArrowUp", "ArrowDown"].includes(e.key)) {
+                    e.preventDefault();
+                    const idx = sections.findIndex((s) => s.id === activeSection);
+                    let nextIdx = e.key === "ArrowUp" ? idx - 1 : idx + 1;
+                    if (nextIdx < 0) nextIdx = sections.length - 1;
+                    if (nextIdx >= sections.length) nextIdx = 0;
+                    setActiveSection(sections[nextIdx].id);
+                    document.getElementById(`settings-tab-${sections[nextIdx].id}`)?.focus();
+                  }
+                }}
+              >
+                {sections.map((section) => (
+                  <button
+                    key={section.id}
+                    id={`settings-tab-${section.id}`}
+                    onClick={() => setActiveSection(section.id)}
+                    className={`w-full flex items-center space-x-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
+                      activeSection === section.id
+                        ? 'bg-gradient-to-r from-primary to-secondary text-white shadow-md shadow-primary/20'
+                        : 'text-text-secondary hover:text-text-primary hover:bg-surface-700/40'
+                    }`}
+                    role="tab"
+                    aria-selected={activeSection === section.id}
+                    aria-controls={`settings-tabpanel-${section.id}`}
+                    tabIndex={activeSection === section.id ? 0 : -1}
+                  >
+                    <Icon name={section.icon} className="w-4 h-4" />
+                    <span>{section.label}</span>
+                  </button>
+                ))}
+              </nav>
+            )}
+          </Card>
+        </aside>
+
+        {/* Main Content */}
+        <main className="flex-1 min-h-[600px] transition-all duration-200" style={{ contain: 'layout' }}>
+          <div className="min-h-full">{renderSection()}</div>
+        </main>
       </div>
-    </div>
+    </Page>
   );
 };
 

--- a/src/pages/temp-todos/index.jsx
+++ b/src/pages/temp-todos/index.jsx
@@ -8,6 +8,9 @@ import Icon from '../../components/ui/Icon';
 import Button from '../../components/ui/Button';
 import TodoItem from '../../components/ui/TodoItem';
 import CelebrationEffect from '../../components/ui/CelebrationEffect';
+import Page from '../../components/ui/Page';
+import PageHeader from '../../components/ui/PageHeader';
+import EmptyState from '../../components/ui/EmptyState';
 
 const TemporaryTodosPage = () => {
   const { user, isAuthenticated } = useAuth();
@@ -211,54 +214,46 @@ const TemporaryTodosPage = () => {
 
   if (!isAuthenticated) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h2 className="text-2xl font-heading-bold text-text-primary mb-4">
-            Please sign in to access Temporary Todos
-          </h2>
-        </div>
-      </div>
+      <Page width="md">
+        <EmptyState
+          icon="LogIn"
+          title="Sign in required"
+          description="Please sign in to access your Quick Todos."
+          size="lg"
+        />
+      </Page>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background to-surface/30">
-      <div className="max-w-4xl mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="mb-8">
-          <motion.div
-            initial={{ opacity: 0, y: -20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="flex items-center justify-between"
-          >
-            <div>
-              <h1 className="text-3xl font-heading-bold text-text-primary mb-2 bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-                Quick Todos ⚡
-              </h1>
-              <p className="text-text-secondary">
-                Capture quick thoughts and let Drift AI help prioritize what matters most
-              </p>
-            </div>
-            <div className="flex gap-3">
-              <Button
-                onClick={() => setShowArchive(!showArchive)}
-                variant="secondary"
-                className="flex items-center gap-2 hover:scale-105 transition-transform"
-              >
-                <Icon name="Archive" className="w-4 h-4" />
-                {showArchive ? 'Hide Archive' : 'Show Archive'}
-              </Button>
-              <Button
-                onClick={() => setShowAIAssistant(!showAIAssistant)}
-                variant="primary"
-                className="flex items-center gap-2 hover:scale-105 transition-transform bg-gradient-to-r from-primary to-secondary"
-              >
-                <Icon name="Zap" className="w-4 h-4" />
-                Drift AI
-              </Button>
-            </div>
-          </motion.div>
-        </div>
+    <Page width="lg" background="gradient">
+      <PageHeader
+        icon="Zap"
+        title="Quick Todos"
+        subtitle="Capture quick thoughts and let Drift AI help prioritize what matters most"
+        actions={(
+          <>
+            <Button
+              onClick={() => setShowArchive(!showArchive)}
+              variant="outline"
+              size="sm"
+              iconName="Archive"
+              iconPosition="left"
+            >
+              {showArchive ? 'Hide Archive' : 'Show Archive'}
+            </Button>
+            <Button
+              onClick={() => setShowAIAssistant(!showAIAssistant)}
+              variant="primary"
+              size="sm"
+              iconName="Zap"
+              iconPosition="left"
+            >
+              Drift AI
+            </Button>
+          </>
+        )}
+      />
 
         {/* Add Todo Form */}
         <motion.div
@@ -477,7 +472,6 @@ const TemporaryTodosPage = () => {
             </motion.div>
           )}
         </AnimatePresence>
-      </div>
 
       {/* Celebration Effect */}
       <CelebrationEffect 
@@ -587,7 +581,7 @@ const TemporaryTodosPage = () => {
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
+    </Page>
   );
 };
 


### PR DESCRIPTION
## Summary

This PR has two parts:

**1) Real feature bugs fixed**

- **Habits page crash** — `src/pages/habits/index.jsx` was missing the `CreativeHabitsTree` import, so the habits view crashed once any habit existed.
- **Logout 404** — `src/components/ui/Header.jsx` was navigating to `/auth/login` (which is not a registered route) on sign‑out. Changed to `/login`.
- **NotFound colors** — `src/pages/NotFound.jsx` referenced an undefined `text-onBackground` class. Switched to the project's `text-text-primary` / `text-text-secondary` tokens so the 404 page renders correctly in both light and dark themes.
- **Day planner modals never rendered** — Both `<AddEventModal>` and `<PreferencesModal>` were defined but never mounted in the page tree, so the "Add Event" and "Preferences" buttons did nothing. They are now rendered and wired up.
- **Day planner Drift handler** — `DayPlanner.handleDriftPlan` referenced `setIsDriftLoading` and `setDriftPrompt`, which only exist inside the modal. Cleaned up so it uses the page's own `setIsGenerating` instead.

**2) UI unified across the app**

Added a small set of shared primitives in `src/components/ui/`:

- `Page.jsx` – consistent full‑height wrapper, max‑width container, padding, and entrance animation.
- `PageHeader.jsx` – gradient icon tile + title + subtitle + actions slot.
- `Card.jsx` – `default`/`elevated`/`glass`/`gradient` variants with consistent radius, border, shadow.
- `StatCard.jsx` – icon + label + value + sublabel for dashboard metrics.
- `TabBar.jsx` – `pill`/`underline`/`segmented` variants with motion‑animated active indicator.
- `EmptyState.jsx` – icon + title + description + action(s) for empty lists.
- `Modal.jsx` – backdrop blur, glass surface, escape‑to‑close, body scroll lock, framer‑motion enter/exit.

These primitives are then applied across the app so every screen shares the same header pattern, card surfaces, tab style, empty states, and modals:

- `goals-dashboard` — Page + onboarding modal converted to `<Modal>` + unified empty state.
- `temp-todos` — Page + PageHeader (gradient header), header buttons normalized.
- `habits` — Page + PageHeader + EmptyState + missing import fixed.
- `meals` — Page + PageHeader + StatCard grid + TabBar + EmptyState (full refactor).
- `journal` — Page + PageHeader + StatCard grid + Card + EmptyState.
- `day` — Page + PageHeader + EmptyState (api‑key/connection/empty‑plan states) + Add Event/Preferences modals migrated to `<Modal>`.
- `progress` — Page + PageHeader + Card (Quick Actions) + EmptyState.
- `analytics-dashboard` — Page + PageHeader + TabBar (replacing custom inline tabs).
- `achievements` — Page + PageHeader + StatCard summary grid + TabBar + Card list items + EmptyState.
- `settings-configuration` — Page + PageHeader + sidebar in a Card + gradient‑pill active tab.
- `ai-assistant-chat-drift` — All four pre‑chat states (sign‑in required, API key required, invalid key, initializing) converted to `<Page>` + `<EmptyState>` for consistency. The chat itself keeps its full‑height layout.

`focus-mode` is intentionally left as a unique fullscreen experience.

## Review & Testing Checklist for Human

- [ ] Sign in and load each page in the side nav (Goals, Day, Progress, Analytics, Habits, Meals, Journal, Quick Todos, Achievements, Drift, Settings) — verify each renders the new `<PageHeader>` and there are no console errors.
- [ ] Habits: create a habit and confirm the page no longer crashes (the `CreativeHabitsTree` import fix).
- [ ] Header user menu → Sign Out: confirm it lands on `/login` (not a 404).
- [ ] Day: click "Add Event" and "Preferences" — both modals now open. Add an event and confirm it shows up in the plan.
- [ ] Visit a non‑existent route (e.g. `/foo`) and confirm the 404 page text is readable in light + dark.
- [ ] Toggle the theme between light and dark and spot‑check that cards / headers / empty states look consistent.
- [ ] Run `npm run build` locally — `vite build` succeeds (verified locally).

### Notes

- No public component APIs were removed; the new primitives are additive.
- `focus-mode` and the chat thread layout in `ai-assistant-chat-drift` were intentionally not wrapped in `<Page>` because they need full‑viewport layouts.
- `npm run lint` is not configured in this repo (only `start`, `build`, `serve` scripts), so verification is via `vite build`.

Link to Devin session: https://app.devin.ai/sessions/a291d10f1d0c48bdba2be7b3853fce4a
Requested by: @yaegerbomb42